### PR TITLE
Improve behavior in some unexpected situations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@ Changelog for Ansible Changelog Tool
 ====================================
 
 
+v0.3.1
+======
+
+Bugfixes
+--------
+
+- Improve error message when ``--is-collection`` is specified and ``changelogs/config.yaml`` cannot be found, or when the ``lint`` subcommand is used.
+- Improve behavior when ``changelogs/config.yaml`` is not a dictionary, or does not contain ``sections``.
+- Do not fail when ``changelogs/fragments`` does not exist. Simply assume there are no fragments in that case.
+
 v0.3.0
 ======
 

--- a/antsibull_changelog/cli.py
+++ b/antsibull_changelog/cli.py
@@ -51,9 +51,17 @@ def set_paths(force: Optional[str] = None,
     try:
         return PathsConfig.detect(is_collection=is_collection, ansible_doc_bin=ansible_doc_bin)
     except ChangelogError:
+        if is_collection is True:
+            raise ChangelogError(
+                "Only the 'init' command can be used outside a collection repository, "
+                "or inside one without changelogs/config.yaml.")
+        if is_collection is False:
+            raise ChangelogError(
+                "Only the 'init' command can be used outside an Ansible checkout, "
+                "or inside one without changelogs/config.yaml.")
         raise ChangelogError(
-            "Only the 'init' and 'lint-changelog' commands can be used outside an "
-            "Ansible checkout and outside a collection repository.\n"
+            "Only the 'init' command can be used outside an Ansible checkout and outside a "
+            "collection repository, or inside one without changelogs/config.yaml.\n"
             "If you are in a collection without galaxy.yml, specify `--is-collection no` "
             "on the command line.")
 

--- a/antsibull_changelog/config.py
+++ b/antsibull_changelog/config.py
@@ -227,6 +227,18 @@ class CollectionDetails:
         return flatmap
 
 
+DEFAULT_SECTIONS = [
+    ['major_changes', 'Major Changes'],
+    ['minor_changes', 'Minor Changes'],
+    ['breaking_changes', 'Breaking Changes / Porting Guide'],
+    ['deprecated_features', 'Deprecated Features'],
+    ['removed_features', 'Removed Features (previously deprecated)'],
+    ['security_fixes', 'Security Fixes'],
+    ['bugfixes', 'Bugfixes'],
+    ['known_issues', 'Known Issues'],
+]
+
+
 class ChangelogConfig:
     # pylint: disable=too-many-instance-attributes
     """
@@ -293,7 +305,7 @@ class ChangelogConfig:
                                  'combined with keep_fragments == False')
 
         sections = collections.OrderedDict([(self.prelude_name, self.prelude_title)])
-        for section_name, section_title in self.config['sections']:
+        for section_name, section_title in self.config.get('sections', DEFAULT_SECTIONS):
             sections[section_name] = section_title
         self.sections = sections
 
@@ -340,6 +352,8 @@ class ChangelogConfig:
         Load changelog configuration file from disk.
         """
         config = load_yaml(paths.config_path)
+        if not isinstance(config, dict):
+            raise ChangelogError('{0} must be a dictionary'.format(paths.config_path))
         return ChangelogConfig(paths, collection_details, config)
 
     @staticmethod
@@ -356,16 +370,7 @@ class ChangelogConfig:
             'changelog_filename_template': 'CHANGELOG.rst',
             'changelog_filename_version_depth': 0,
             'new_plugins_after_name': 'removed_features',
-            'sections': [
-                ['major_changes', 'Major Changes'],
-                ['minor_changes', 'Minor Changes'],
-                ['breaking_changes', 'Breaking Changes / Porting Guide'],
-                ['deprecated_features', 'Deprecated Features'],
-                ['removed_features', 'Removed Features (previously deprecated)'],
-                ['security_fixes', 'Security Fixes'],
-                ['bugfixes', 'Bugfixes'],
-                ['known_issues', 'Known Issues'],
-            ],
+            'sections': DEFAULT_SECTIONS,
         }
         if title is not None:
             config['title'] = title

--- a/antsibull_changelog/fragment.py
+++ b/antsibull_changelog/fragment.py
@@ -180,9 +180,12 @@ def load_fragments(paths: PathsConfig, config: ChangelogConfig,
     """
     if not fragment_paths:
         fragments_dir = os.path.join(paths.changelog_dir, config.notes_dir)
-        fragment_paths = [
-            os.path.join(fragments_dir, path)
-            for path in os.listdir(fragments_dir) if not path.startswith('.')]
+        if os.path.isdir(fragments_dir):
+            fragment_paths = [
+                os.path.join(fragments_dir, path)
+                for path in os.listdir(fragments_dir) if not path.startswith('.')]
+        else:
+            fragment_paths = []
 
     fragments: List[ChangelogFragment] = []
 


### PR DESCRIPTION
Like:
- `changelogs/config.yaml` is not present (better error messages)
- `changelogs/config.yaml` is not a directory, or does not contain `sections`
- `changelogs/fragments` does not exist (or is no directory)
