### PR TITLE
Ignore non-yaml-ish file suffixes

### DIFF
--- a/antsibull_changelog/fragment.py
+++ b/antsibull_changelog/fragment.py
@@ -203,7 +203,7 @@ def load_fragments(paths: PathsConfig, config: ChangelogConfig,
         if os.path.isdir(fragments_dir):
             fragment_paths = [
                 os.path.join(fragments_dir, path)
-                for path in os.listdir(fragments_dir) if not path.startswith('.')]
+                for path in os.listdir(fragments_dir) if not path.startswith('.') and path.endswith(('.yml', '.yaml', '.json'))]
         else:
             fragment_paths = []
 

--- a/tests/units/test_fragment.py
+++ b/tests/units/test_fragment.py
@@ -35,3 +35,13 @@ def test_fragment_loading_fail(tmp_path):
     p.write_text('test: [')
     with pytest.raises(ChangelogError):
         load_fragments(paths, config, [str(p)])
+
+def test_fragments_dir_ignores_backup_files(tmp_path):
+    '''Ensure we don't load files we mean to ignore'''
+    paths = PathsConfig.force_ansible(str(tmp_path))
+    config = ChangelogConfig.default(paths, CollectionDetails(paths))
+    test_filenames = ['.test.yaml', 'test.yaml~', 'test.yml~', 'test.foo']
+    for fn in test_filenames:
+        p = tmp_path / fn
+        p.write_text('minor_changes: ["foo"]')
+        assert load_fragments(paths, config, [], None, tmp_path) == []


### PR DESCRIPTION
Change:
- In addition to dropping dotfiles, limit included files to things that
  actually indicate parsable YAML (including .json) and drop everything
  else.
- Add unit test

Signed-off-by: Rick Elrod <rick@elrod.me>