### PR TITLE
Fix example with release date

### DIFF
--- a/docs/changelog.yaml-format.md
+++ b/docs/changelog.yaml-format.md
@@ -58,7 +58,7 @@ The following is an example of release information for version `1.0.0`:
 ```.yaml
 releases:
   1.0.0:
-    release_date: 2020-04-01
+    release_date: '2020-04-01'
     codename: White Rabbit
     changes:
       release_summary: This is the initial White Rabbit release. Enjoy!


### PR DESCRIPTION
Because changelog.yaml should be YAML 1.1 file, we need to be a bit careful with bare YYYY-MM-DD literals since those are interpreted as dates and thus do not conform to the specification of the changelog file.