### PR TITLE
Support roles with argument spec and `main` entrypoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,14 @@ Changelog for Ansible Changelog Tool
    :local:
    :depth: 1
 
-v0.10.1
 =======
+v0.11.0
+=======
+
+Minor Changes
+-------------
+
+- When using ansible-core 2.11 or newer, will now detect new roles with argument spec. We only consider the ``main`` entrypoint of roles.
 
 Bugfixes
 --------

--- a/antsibull_changelog/ansible.py
+++ b/antsibull_changelog/ansible.py
@@ -9,6 +9,8 @@ Return Ansible-specific information, like current release or list of documentabl
 
 from typing import Tuple
 
+import packaging.version
+
 try:
     from ansible import constants as C
     HAS_ANSIBLE_CONSTANTS = True
@@ -42,6 +44,17 @@ def get_documentable_plugins() -> Tuple[str, ...]:
         'become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory',
         'lookup', 'netconf', 'shell', 'vars', 'module', 'strategy',
     )
+
+
+def get_documentable_objects() -> Tuple[str, ...]:
+    """
+    Retrieve object types that can be documented.
+    """
+    if not HAS_ANSIBLE_RELEASE:
+        return ()
+    if packaging.version.Version(ansible_release.__version__) < packaging.version.Version('2.11.0'):
+        return ()
+    return ('role', )
 
 
 def get_ansible_release() -> Tuple[str, str]:

--- a/antsibull_changelog/ansible.py
+++ b/antsibull_changelog/ansible.py
@@ -7,7 +7,7 @@
 Return Ansible-specific information, like current release or list of documentable plugins.
 """
 
-from typing import Tuple
+from typing import Any, Tuple
 
 import packaging.version
 
@@ -18,10 +18,12 @@ except ImportError:
     HAS_ANSIBLE_CONSTANTS = False
 
 
+ansible_release: Any
 try:
     from ansible import release as ansible_release
     HAS_ANSIBLE_RELEASE = True
 except ImportError:
+    ansible_release = None
     HAS_ANSIBLE_RELEASE = False
 
 

--- a/antsibull_changelog/cli.py
+++ b/antsibull_changelog/cli.py
@@ -364,6 +364,7 @@ def _do_refresh(args: Any,  # pylint: disable=too-many-arguments
         allow_removals = (refresh_plugins == 'allow-removal')
 
         changes.update_plugins(plugins, allow_removals=allow_removals)
+        changes.update_objects(plugins, allow_removals=allow_removals)
 
     if refresh_fragments:
         if fragments is None:
@@ -445,7 +446,9 @@ def command_release(args: Any) -> int:
         cast(List[ChangelogFragment], fragments),
         version, codename, date,
         update_existing=args.update_existing,
-        prev_version=prev_version)
+        prev_version=prev_version,
+        objects=cast(List[PluginDescription], plugins),
+    )
     generate_changelog(paths, config, changes, plugins, fragments, flatmap=flatmap)
 
     return 0

--- a/tests/functional/fixtures.py
+++ b/tests/functional/fixtures.py
@@ -421,6 +421,21 @@ class CollectionChangelogEnvironment(ChangelogEnvironment):
 
         return fake_subprocess_ansible_doc
 
+    def add_role(self, name, entry_points):
+        role_meta_dir = os.path.join(self.paths.base_dir, 'roles', name, 'meta')
+        self.mkdir(role_meta_dir)
+        main = yaml.dump({
+            'galaxy_info': {
+                'role_name': name,
+            },
+            'dependencies': [],
+        }, Dumper=yaml.SafeDumper).encode('utf-8')
+        self._write(os.path.join(role_meta_dir, 'main.yml'), main)
+        argspec = yaml.dump({
+            'argument_specs': entry_points,
+        }, Dumper=yaml.SafeDumper).encode('utf-8')
+        self._write(os.path.join(role_meta_dir, 'argument_spec.yml'), argspec)
+
 
 @pytest.fixture
 def ansible_changelog(tmp_path_factory) -> AnsibleChangelogEnvironment:


### PR DESCRIPTION
Since ansible-core 2.11, ansible-doc allows listing roles with an argument spec, which have documentation per entry points. If such a role has a `main` entrypoint whose documentation contains `version_added`, antsibull-changelog will now consider it for automatically detecting new roles.