### PR TITLE
Fix bug when using namespaces in ansible-base/-core without --use-ansible-doc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ Changelog for Ansible Changelog Tool
    :local:
    :depth: 1
 
+v0.10.1
+=======
+
+Bugfixes
+--------
+
+- When subdirectories of ``modules`` are used in ansible-base/ansible-core, the wrong module name was passed to ``ansible-doc`` when ``--use-ansible-doc`` was not used.
+
 v0.10.0
 =======
 

--- a/antsibull_changelog/plugins.py
+++ b/antsibull_changelog/plugins.py
@@ -175,9 +175,11 @@ def list_plugins_walk(paths: PathsConfig,
                 if (plugin_type, filename) in PLUGIN_EXCEPTIONS:
                     continue
             path = follow_links(os.path.join(dirpath, filename))
-            if path.endswith('.py'):
-                path = path[:-len('.py')]
+            path = os.path.splitext(path)[0]
             relpath = os.path.relpath(path, plugin_source_path)
+            if not paths.is_collection and os.sep in relpath:
+                # When listing modules in ansible-base/-core, get rid of the namespace.
+                relpath = os.path.basename(relpath)
             relname = relpath.replace(os.sep, '.')
             if collection_name:
                 relname = '{0}.{1}'.format(collection_name, relname)

--- a/tests/functional/test_changelog_basic_ansible.py
+++ b/tests/functional/test_changelog_basic_ansible.py
@@ -763,9 +763,9 @@ def fake_ansible_doc_ansible(paths: PathsConfig,
             }
         }
     if plugin_type == 'module':
-        assert sorted(plugin_names) == ['cloud.sky.old_module', 'test_module']
+        assert sorted(plugin_names) == ['old_module', 'test_module']
         return {
-            'cloud.sky.old_module': {
+            'old_module': {
                 'doc': {
                     'author': ['Elder'],
                     'description': ['This is an old module.'],

--- a/tests/functional/test_changelog_basic_ansible_classic.py
+++ b/tests/functional/test_changelog_basic_ansible_classic.py
@@ -682,9 +682,9 @@ def fake_ansible_doc_ansible(paths: PathsConfig,
             }
         }
     if plugin_type == 'module':
-        assert sorted(plugin_names) == ['cloud.sky.old_module', 'test_module']
+        assert sorted(plugin_names) == ['old_module', 'test_module']
         return {
-            'cloud.sky.old_module': {
+            'old_module': {
                 'doc': {
                     'author': ['Elder'],
                     'description': ['This is an old module.'],


### PR DESCRIPTION
Found while working on #55. That one will also contain better tests for this.