### PR TITLE
Support other projects than ansible-core and Ansible collections

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,9 @@
 ====================================
-Changelog for Ansible Changelog Tool
+Ansible Changelog Tool Release Notes
 ====================================
 
-.. contents::
-   :local:
-   :depth: 1
+.. contents:: Topics
+
 
 v0.11.0
 =======
@@ -36,11 +35,6 @@ Bugfixes
 v0.9.0
 ======
 
-Breaking Changes
-----------------
-
-- The new option ``prevent_known_fragments`` with default value being the value of ``keep_fragments`` allows to control whether fragments with names that already appeared in the past are ignored or not. The new behavior happens if ``keep_fragments=false``, and is less surprising to users (see https://github.com/ansible-community/antsibull-changelog/issues/46). Changelogs with ``keep_fragments=true``, like the ansible-base/ansible-core changelog, are not affected.
-
 Major Changes
 -------------
 
@@ -69,6 +63,11 @@ Minor Changes
 
 - Add ``--update-existing`` option for ``antsibull-changelog release``, which allows to update the current release's release date and (if relevant) codename instead of simply reporting that the release already exists.
 
+Breaking Changes / Porting Guide
+--------------------------------
+
+- The new option ``prevent_known_fragments`` with default value being the value of ``keep_fragments`` allows to control whether fragments with names that already appeared in the past are ignored or not. The new behavior happens if ``keep_fragments=false``, and is less surprising to users (see https://github.com/ansible-community/antsibull-changelog/issues/46). Changelogs with ``keep_fragments=true``, like the ansible-base/ansible-core changelog, are not affected.
+
 v0.8.1
 ======
 
@@ -83,8 +82,8 @@ v0.8.0
 Minor Changes
 -------------
 
-- Allow to sanitize changelog data on load/save. This means that unknown information will be removed, and bad information will be stripped. This will be enabled in newly created changelog configs, but is disabled for backwards compatibility.
 - Allow to not save a changelog on release when using API.
+- Allow to sanitize changelog data on load/save. This means that unknown information will be removed, and bad information will be stripped. This will be enabled in newly created changelog configs, but is disabled for backwards compatibility.
 
 v0.7.0
 ======
@@ -93,8 +92,8 @@ Minor Changes
 -------------
 
 - A new config option, ``ignore_other_fragment_extensions`` allows for configuring whether only ``.yaml`` and ``.yml`` files are used (as mandated by the ``ansible-test sanity --test changelog`` test). The default value for existing configurations is ``false``, and for new configurations ``true``.
-- Refactoring changelog generation code to provide all preludes (release summaries) in changelog entries, and provide generic functionality to extract a grouped list of versions. These changes are mainly for the antsibull project.
 - Allow to use semantic versioning also for Ansible-base with the ``use_semantic_versioning`` configuration setting.
+- Refactoring changelog generation code to provide all preludes (release summaries) in changelog entries, and provide generic functionality to extract a grouped list of versions. These changes are mainly for the antsibull project.
 
 v0.6.0
 ======
@@ -102,8 +101,8 @@ v0.6.0
 Minor Changes
 -------------
 
-- The config option ``archive_path_template`` allows to move fragments into an archive directory when ``keep_fragments`` is set to ``false``.
 - New changelog configurations place the ``CHANGELOG.rst`` file by default in the top-level directory, and not in ``changelogs/``.
+- The config option ``archive_path_template`` allows to move fragments into an archive directory when ``keep_fragments`` is set to ``false``.
 - The option ``use_fqcn`` (set to ``true`` in new configurations) allows to use FQCN for new plugins and modules.
 
 v0.5.0
@@ -133,9 +132,9 @@ v0.3.1
 Bugfixes
 --------
 
-- Improve error message when ``--is-collection`` is specified and ``changelogs/config.yaml`` cannot be found, or when the ``lint`` subcommand is used.
-- Improve behavior when ``changelogs/config.yaml`` is not a dictionary, or does not contain ``sections``.
 - Do not fail when ``changelogs/fragments`` does not exist. Simply assume there are no fragments in that case.
+- Improve behavior when ``changelogs/config.yaml`` is not a dictionary, or does not contain ``sections``.
+- Improve error message when ``--is-collection`` is specified and ``changelogs/config.yaml`` cannot be found, or when the ``lint`` subcommand is used.
 
 v0.3.0
 ======
@@ -143,8 +142,8 @@ v0.3.0
 Minor Changes
 -------------
 
-- Changelog generator can be ran via ``python -m antsibull_changelog``.
 - Allow to pass path to ansible-doc binary via ``--ansible-doc-bin``.
+- Changelog generator can be ran via ``python -m antsibull_changelog``.
 - Use ``ansible-doc`` instead of ``/path/to/checkout/bin/ansible-doc`` when being run in ansible-base checkouts.
 
 v0.2.1
@@ -161,15 +160,18 @@ v0.2.0
 Minor Changes
 -------------
 
-- Title generation improved (remove superfluous space).
-- ``lint`` subcommand no longer requires specification whether it is run inside a collection or not (if usual indicators are absent).
-- Improve reStructuredText creation when new modules with and without namespace exist at the same time.
-- Improve error handling.
-- Fix internal API for ACD changelog generation (pruning and concatenation of changelogs).
-- Use PyYAML C loader/dumper if available.
 - Added more testing.
+- Fix internal API for ACD changelog generation (pruning and concatenation of changelogs).
+- Improve error handling.
+- Improve reStructuredText creation when new modules with and without namespace exist at the same time.
+- Title generation improved (remove superfluous space).
+- Use PyYAML C loader/dumper if available.
+- ``lint`` subcommand no longer requires specification whether it is run inside a collection or not (if usual indicators are absent).
 
 v0.1.0
 ======
+
+Release Summary
+---------------
 
 Initial release as antsibull-changelog. The Ansible Changelog Tool has originally been developed by @mattclay in `the ansible/ansible <https://github.com/ansible/ansible/blob/stable-2.9/packaging/release/changelogs/changelog.py>`_ repository for Ansible itself. It has been extended in `felixfontein/ansible-changelog <https://github.com/felixfontein/ansible-changelog/>`_ and `ansible-community/antsibull <https://github.com/ansible-community/antsibull/>`_ to work with collections, until it was moved to its current location `ansible-community/antsibull-changelog <https://github.com/ansible-community/antsibull-changelog/>`_.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 A changelog generator used by ansible-core and Ansible collections.
 
 - Using the
-  [`antsibull-changelog` CLI tool](https://github.com/ansible-community/antsibull-changelog/tree/main/docs/changelogs.rst).
+  [`antsibull-changelog` CLI tool for collections](https://github.com/ansible-community/antsibull-changelog/tree/main/docs/changelogs.rst).
+- Using the
+  [`antsibull-changelog` CLI tool for other projects](https://github.com/ansible-community/antsibull-changelog/tree/main/docs/other-projects.rst).
 - Documentation on the [`changelogs/config.yaml` configuration file for `antsibull-changelog`](https://github.com/ansible-community/antsibull-changelog/tree/main/docs/changelog-configuration.rst).
 - Documentation on the
   [`changelog.yaml` format](https://github.com/ansible-community/antsibull-changelog/tree/main/docs/changelog.yaml-format.md).

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ A changelog generator used by ansible-core and Ansible collections.
 - Documentation on the
   [`changelog.yaml` format](https://github.com/ansible-community/antsibull-changelog/tree/main/docs/changelog.yaml-format.md).
 
-It is now also possible to use antsibull-changelog to create changelogs for other projects.
-
 antsibull-changelog is covered by the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ to create a `setup.py` file from `pyproject.toml`:
 
 Then you can install antsibull-changelog with `pip install -e .`.
 
+## Build a release
+
+First update the `version` entry in `pyproject.toml`. Then generate the changelog:
+
+    antsibull-changelog release --version <version-number>
+
+Then build the build artefact:
+
+    poetry build
+
+Finally, publish to PyPi:
+
+    poetry publish
+
+Then tag the current state with the release version and push the tag to the repository.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
 [![Python testing badge](https://github.com/ansible-community/antsibull-changelog/workflows/Python%20testing/badge.svg?event=push&branch=main)](https://github.com/ansible-community/antsibull-changelog/actions?query=workflow%3A%22Python+testing%22+branch%3Amain)
 [![Codecov badge](https://img.shields.io/codecov/c/github/ansible-community/antsibull-changelog)](https://codecov.io/gh/ansible-community/antsibull-changelog)
 
-A changelog generator used by Ansible and Ansible collections.
+A changelog generator used by ansible-core and Ansible collections.
 
 - Using the
   [`antsibull-changelog` CLI tool](https://github.com/ansible-community/antsibull-changelog/tree/main/docs/changelogs.rst).
 - Documentation on the [`changelogs/config.yaml` configuration file for `antsibull-changelog`](https://github.com/ansible-community/antsibull-changelog/tree/main/docs/changelog-configuration.rst).
 - Documentation on the
   [`changelog.yaml` format](https://github.com/ansible-community/antsibull-changelog/tree/main/docs/changelog.yaml-format.md).
+
+It is now also possible to use antsibull-changelog to create changelogs for other projects.
 
 antsibull-changelog is covered by the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
 

--- a/antsibull_changelog/changes.py
+++ b/antsibull_changelog/changes.py
@@ -435,7 +435,7 @@ class ChangesData(ChangesBase):
     """
     Read, write and manage modern change metadata.
 
-    This is the format used for ansible-base 2.10+ and for Ansible collections.
+    This is the format used for ansible-base 2.10, ansible-core 2.11+, and for Ansible collections.
     """
 
     config: ChangelogConfig

--- a/antsibull_changelog/cli.py
+++ b/antsibull_changelog/cli.py
@@ -411,7 +411,7 @@ def command_release(args: Any) -> int:
     flatmap = _determine_flatmap(collection_details, config)
 
     if not version or not codename:
-        if not config.is_collection:
+        if not config.is_collection and not paths.is_other_project:
             # Both version and codename are required for Ansible (Base)
             try:
                 version, codename = get_ansible_release()
@@ -419,9 +419,12 @@ def command_release(args: Any) -> int:
                 LOGGER.error('Cannot import ansible.release to determine version and codename')
                 return 5
 
-        elif not version:
+        elif config.is_collection and not version:
             # Codename is not required for collections, only version is
             version = collection_details.get_version()
+        elif paths.is_other_project and not version:
+            LOGGER.error('You need to explicitly specify the version for other projects with --version')
+            return 5
 
     changes = load_changes(config)
 

--- a/antsibull_changelog/cli.py
+++ b/antsibull_changelog/cli.py
@@ -46,7 +46,7 @@ def set_paths(force: Optional[str] = None,
     :arg is_other_project: Override detection of whether the tool is an other project
     """
     if force is not None:
-        if is_other_project:
+        if is_other_project is True:
             return PathsConfig.force_other(force, ansible_doc_bin=ansible_doc_bin)
         if is_collection is False:
             return PathsConfig.force_ansible(force, ansible_doc_bin=ansible_doc_bin)

--- a/antsibull_changelog/cli.py
+++ b/antsibull_changelog/cli.py
@@ -40,7 +40,7 @@ def set_paths(force: Optional[str] = None,
     :arg force: If ``True``, create a collection path config for the given path.
                 Otherwise, detect configuration.
     :arg is_collection: Override detection of whether the tool is run in a collection
-                        or in ansible-base.
+                        or in ansible-core.
     :arg ansible_doc_bin: Override path to ansible-doc.
     """
     if force:

--- a/antsibull_changelog/cli.py
+++ b/antsibull_changelog/cli.py
@@ -411,7 +411,7 @@ def command_release(args: Any) -> int:
     flatmap = _determine_flatmap(collection_details, config)
 
     if not version or not codename:
-        if not config.is_collection and not paths.is_other_project:
+        if not config.is_collection and not config.is_other_project:
             # Both version and codename are required for Ansible (Base)
             try:
                 version, codename = get_ansible_release()

--- a/antsibull_changelog/cli.py
+++ b/antsibull_changelog/cli.py
@@ -419,12 +419,14 @@ def command_release(args: Any) -> int:
                 LOGGER.error('Cannot import ansible.release to determine version and codename')
                 return 5
 
-        elif config.is_collection and not version:
-            # Codename is not required for collections, only version is
-            version = collection_details.get_version()
-        elif paths.is_other_project and not version:
-            LOGGER.error('You need to explicitly specify the version for other projects with --version')
-            return 5
+        elif not version:
+            if config.is_collection:
+                # Codename is not required for collections, only version is
+                version = collection_details.get_version()
+            else:
+                LOGGER.error('You need to explicitly specify the version for other projects with'
+                             ' --version')
+                return 5
 
     changes = load_changes(config)
 

--- a/antsibull_changelog/config.py
+++ b/antsibull_changelog/config.py
@@ -365,7 +365,7 @@ class ChangelogConfig:
         """
         if self.is_other_project != self.paths.is_other_project:
             raise ChangelogError(
-                'is_other_project must be {0}'.format(self.paths.is_other_project))
+                'is_other_project must be {0}'.format(self.is_other_project))
         if self.is_other_project and self.is_collection:
             raise ChangelogError('is_other_project must not be True for collections')
         if self.changes_format not in ('classic', 'combined'):

--- a/antsibull_changelog/config.py
+++ b/antsibull_changelog/config.py
@@ -461,8 +461,10 @@ class ChangelogConfig:
             'use_fqcn': True,
             'ignore_other_fragment_extensions': True,
             'sanitize_changelog': True,
-            'is_other_project': paths.is_other_project,
         }
         if title is not None:
             config['title'] = title
+        if paths.is_other_project:
+            config['is_other_project'] = True
+            config['use_semantic_versioning'] = True
         return ChangelogConfig(paths, collection_details, config)

--- a/antsibull_changelog/config.py
+++ b/antsibull_changelog/config.py
@@ -87,9 +87,9 @@ class PathsConfig:
     def force_ansible(base_dir: str,
                       ansible_doc_bin: Optional[str] = None) -> 'PathsConfig':
         """
-        Forces configuration with given Ansible Base base path.
+        Forces configuration with given ansible-core/-base base path.
 
-        :type base_dir: Base directory of ansible-base checkout
+        :type base_dir: Base directory of ansible-core/-base checkout
         :arg ansible_doc_bin: Override path to ansible-doc.
         """
         base_dir = os.path.abspath(base_dir)
@@ -114,7 +114,8 @@ class PathsConfig:
         """
         Detect paths configuration from current working directory.
 
-        :raises ChangelogError: cannot identify collection or ansible-base checkout
+        :raises ChangelogError: cannot identify collection, ansible-core/-base checkout,
+                                or other project.
         :arg ansible_doc_bin: Override path to ansible-doc.
         """
         previous: Optional[str] = None
@@ -138,7 +139,8 @@ class PathsConfig:
                     return PathsConfig(False, base_dir, None, ansible_doc_bin)
             previous, base_dir = base_dir, os.path.dirname(base_dir)
             if previous == base_dir:
-                raise ChangelogError('Cannot identify collection or ansible-base checkout.')
+                raise ChangelogError('Cannot identify collection, ansible-core/-base'
+                                     ' checkout, or other project.')
 
 
 def load_galaxy_metadata(paths: PathsConfig) -> dict:
@@ -342,7 +344,7 @@ class ChangelogConfig:
         self.use_semantic_versioning = True
         self.is_other_project = self.config.get('is_other_project', False)
 
-        # The following are only relevant for ansible-base/-core and other projects:
+        # The following are only relevant for ansible-core/-base and other projects:
         self.release_tag_re = self.config.get(
             'release_tag_re', r'((?:[\d.ab]|rc)+)')
         self.pre_release_tag_re = self.config.get(

--- a/antsibull_changelog/config.py
+++ b/antsibull_changelog/config.py
@@ -125,7 +125,8 @@ class PathsConfig:
             changelog_dir = PathsConfig._changelog_dir(base_dir)
             config_path = PathsConfig._config_path(changelog_dir)
             if os.path.exists(changelog_dir) and os.path.exists(config_path):
-                if is_other_project is True or (not is_collection and _is_other_project_config(config_path)):
+                if is_other_project is True or (
+                        not is_collection and _is_other_project_config(config_path)):
                     # This is neither ansible-core/-base nor an Ansible collection,
                     # but explicitly marked as an 'other project'
                     return PathsConfig(False, base_dir, None, ansible_doc_bin,
@@ -306,7 +307,7 @@ class ChangelogConfig:
     sections: Mapping[str, str]
 
     def __init__(self, paths: PathsConfig, collection_details: CollectionDetails, config: dict,
-                       ignore_is_other_project: bool = False):
+                 ignore_is_other_project: bool = False):
         """
         Create changelog config from dictionary.
         """

--- a/antsibull_changelog/config.py
+++ b/antsibull_changelog/config.py
@@ -22,7 +22,7 @@ def _is_other_project_config(config_path: str) -> bool:
     try:
         config = load_yaml(config_path)
         return config.get('is_other_project', False)
-    except Exception as exc:  # pylint: disable=broad-except
+    except:  # pylint: disable=bare-except;  # noqa: E722
         return False
 
 
@@ -49,7 +49,8 @@ class PathsConfig:
         return os.path.join(changelog_dir, 'config.yaml')
 
     def __init__(self, is_collection: bool, base_dir: str, galaxy_path: Optional[str],
-                 ansible_doc_path: Optional[str], is_other_project: bool = False):
+                 ansible_doc_path: Optional[str], is_other_project: bool = False
+                 ):  # pylint: disable=too-many-arguments
         """
         Forces configuration with given base path.
 
@@ -133,7 +134,8 @@ class PathsConfig:
                 if not is_collection and _is_other_project_config(config_path):
                     # This is neither ansible-core/-base nor an Ansible collection,
                     # but explicitly marked as an 'other project'
-                    return PathsConfig(False, base_dir, None, ansible_doc_bin, is_other_project=True)
+                    return PathsConfig(False, base_dir, None, ansible_doc_bin,
+                                       is_other_project=True)
             previous, base_dir = base_dir, os.path.dirname(base_dir)
             if previous == base_dir:
                 raise ChangelogError('Cannot identify collection or ansible-base checkout.')

--- a/antsibull_changelog/logger.py
+++ b/antsibull_changelog/logger.py
@@ -51,7 +51,7 @@ def setup_logger(verbosity: int) -> None:
     """
     Setup logger.
     """
-    global _LOGGER_SET_UP
+    global _LOGGER_SET_UP  # pylint: disable=global-statement
 
     if not _LOGGER_SET_UP:
         formatter = logging.Formatter('%(levelname)s %(message)s')

--- a/antsibull_changelog/logger.py
+++ b/antsibull_changelog/logger.py
@@ -44,19 +44,26 @@ class FormattingAdapter(logging.LoggerAdapter):
 
 LOGGER = FormattingAdapter(logging.getLogger('changelog'))
 
+_LOGGER_SET_UP = False
+
 
 def setup_logger(verbosity: int) -> None:
     """
     Setup logger.
     """
-    formatter = logging.Formatter('%(levelname)s %(message)s')
+    global _LOGGER_SET_UP
 
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(formatter)
+    if not _LOGGER_SET_UP:
+        formatter = logging.Formatter('%(levelname)s %(message)s')
 
-    LOGGER.addHandler(handler)
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(formatter)
+
+        LOGGER.addHandler(handler)
+
+        _LOGGER_SET_UP = True
+
     LOGGER.setLevel(logging.WARN)
-
     if verbosity > 2:
         LOGGER.setLevel(logging.DEBUG)
     elif verbosity > 1:

--- a/antsibull_changelog/plugins.py
+++ b/antsibull_changelog/plugins.py
@@ -169,7 +169,7 @@ def list_plugins_walk(paths: PathsConfig,
                       plugin_type: str,
                       collection_name: Optional[str]) -> List[str]:
     """
-    Find all plugins of a type in a collection, or in Ansible-base. Uses os.walk().
+    Find all plugins of a type in a collection, or in ansible-core/-base. Uses os.walk().
 
     This will also work with Ansible 2.9.
 
@@ -192,14 +192,14 @@ def list_plugins_walk(paths: PathsConfig,
                 continue
             if not paths.is_collection and dirpath == plugin_source_path:
                 # Skip files which are *not* plugins/modules, but live in these directories inside
-                # ansible-base/-core.
+                # ansible-core/-base.
                 if (plugin_type, filename) in PLUGIN_EXCEPTIONS:
                     continue
             path = follow_links(os.path.join(dirpath, filename))
             path = os.path.splitext(path)[0]
             relpath = os.path.relpath(path, plugin_source_path)
             if not paths.is_collection and os.sep in relpath:
-                # When listing modules in ansible-base/-core, get rid of the namespace.
+                # When listing modules in ansible-core/-base, get rid of the namespace.
                 relpath = os.path.basename(relpath)
             relname = relpath.replace(os.sep, '.')
             if collection_name:
@@ -215,7 +215,7 @@ def list_plugins_ansibledoc(paths: PathsConfig,
                             collection_name: Optional[str],
                             category: str = 'plugin') -> List[str]:
     """
-    Find all plugins of a type in a collection, or in Ansible-base. Uses ansible-doc.
+    Find all plugins of a type in a collection, or in ansible-core/-base. Uses ansible-doc.
 
     Note that ansible-doc from Ansible 2.10 or newer is needed for this!
 
@@ -285,7 +285,7 @@ def load_plugin_metadata(paths: PathsConfig,  # pylint: disable=too-many-argumen
     :arg category: Set to ``object`` for roles and playbooks
     """
     if use_ansible_doc or category == 'object':
-        # WARNING: Do not make this the default to this before ansible-base is a requirement!
+        # WARNING: Do not make this the default to this before ansible-core/-base is a requirement!
         plugins_list = list_plugins_ansibledoc(
             paths, playbook_dir, plugin_type, collection_name, category)
     else:

--- a/antsibull_changelog/plugins.py
+++ b/antsibull_changelog/plugins.py
@@ -379,6 +379,9 @@ def load_plugins(paths: PathsConfig,
     :arg use_ansible_doc: Set to ``True`` to always use ansible-doc to enumerate plugins/modules
     :return: A list of all plugins
     """
+    if paths.is_other_project:
+        return []
+
     plugin_cache_path = os.path.join(paths.changelog_dir, '.plugin-cache.yaml')
     plugins_data: Dict[str, Any] = {}
 

--- a/antsibull_changelog/utils.py
+++ b/antsibull_changelog/utils.py
@@ -39,7 +39,7 @@ def is_release_version(config: ChangelogConfig, version: str) -> bool:
     :arg version: The version to check
     :return: Whether the provided version is a release version
     """
-    if config.is_collection:
+    if config.use_semantic_versioning:
         try:
             return not bool(semantic_version.Version(version).prerelease)
         except Exception as exc:  # pylint: disable=broad-except

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,0 +1,116 @@
+ancestor: null
+releases:
+  0.1.0:
+    changes:
+      release_summary: Initial release as antsibull-changelog. The Ansible Changelog Tool has originally been developed by @mattclay in `the ansible/ansible <https://github.com/ansible/ansible/blob/stable-2.9/packaging/release/changelogs/changelog.py>`_ repository for Ansible itself. It has been extended in `felixfontein/ansible-changelog <https://github.com/felixfontein/ansible-changelog/>`_ and `ansible-community/antsibull <https://github.com/ansible-community/antsibull/>`_ to work with collections, until it was moved to its current location `ansible-community/antsibull-changelog <https://github.com/ansible-community/antsibull-changelog/>`_.
+    release_date: '2020-05-30'
+  0.2.0:
+    changes:
+      minor_changes:
+        - Title generation improved (remove superfluous space).
+        - "``lint`` subcommand no longer requires specification whether it is run inside a collection or not (if usual indicators are absent)."
+        - Improve reStructuredText creation when new modules with and without namespace exist at the same time.
+        - Improve error handling.
+        - Fix internal API for ACD changelog generation (pruning and concatenation of changelogs).
+        - Use PyYAML C loader/dumper if available.
+        - Added more testing.
+    release_date: '2020-05-31'
+  0.2.1:
+    changes:
+      bugfixes:
+        - Allow to enumerate plugins/modules with ansible-doc by specifying ``--use-ansible-doc``.
+    release_date: '2020-06-10'
+  0.3.0:
+    changes:
+      minor_changes:
+        - Changelog generator can be ran via ``python -m antsibull_changelog``.
+        - Allow to pass path to ansible-doc binary via ``--ansible-doc-bin``.
+        - Use ``ansible-doc`` instead of ``/path/to/checkout/bin/ansible-doc`` when being run in ansible-base checkouts.
+    release_date: '2020-06-10'
+  0.3.1:
+    changes:
+      bugfixes:
+        - Improve error message when ``--is-collection`` is specified and ``changelogs/config.yaml`` cannot be found, or when the ``lint`` subcommand is used.
+        - Improve behavior when ``changelogs/config.yaml`` is not a dictionary, or does not contain ``sections``.
+        - Do not fail when ``changelogs/fragments`` does not exist. Simply assume there are no fragments in that case.
+    release_date: '2020-06-11'
+  0.4.0:
+    changes:
+      minor_changes:
+        - Allow to enable or disable flatmapping via ``config.yaml``.
+      bugfixes:
+        - Fix bad module namespace detection when collection was symlinked into Ansible's collection search path. This also allows to add releases to collections which are not installed in a way that Ansible finds them.
+    release_date: '2020-06-22'
+  0.5.0:
+    changes:
+      minor_changes:
+        - The internal changelog generator code got more flexible to help antsibull generate Ansible porting guides.
+    release_date: '2020-06-28'
+  0.6.0:
+    changes:
+      minor_changes:
+        - The config option ``archive_path_template`` allows to move fragments into an archive directory when ``keep_fragments`` is set to ``false``.
+        - New changelog configurations place the ``CHANGELOG.rst`` file by default in the top-level directory, and not in ``changelogs/``.
+        - The option ``use_fqcn`` (set to ``true`` in new configurations) allows to use FQCN for new plugins and modules.
+    release_date: '2020-07-12'
+  0.7.0:
+    changes:
+      minor_changes:
+        - A new config option, ``ignore_other_fragment_extensions`` allows for configuring whether only ``.yaml`` and ``.yml`` files are used (as mandated by the ``ansible-test sanity --test changelog`` test). The default value for existing configurations is ``false``, and for new configurations ``true``.
+        - Refactoring changelog generation code to provide all preludes (release summaries) in changelog entries, and provide generic functionality to extract a grouped list of versions. These changes are mainly for the antsibull project.
+        - Allow to use semantic versioning also for Ansible-base with the ``use_semantic_versioning`` configuration setting.
+    release_date: '2020-07-26'
+  0.8.0:
+    changes:
+      minor_changes:
+        - Allow to sanitize changelog data on load/save. This means that unknown information will be removed, and bad information will be stripped. This will be enabled in newly created changelog configs, but is disabled for backwards compatibility.
+        - Allow to not save a changelog on release when using API.
+    release_date: '2020-08-18'
+  0.8.1:
+    changes:
+      bugfixes:
+        - Fixed error on generating changelogs when using the trivial section.
+    release_date: '2020-08-27'
+  0.9.0:
+    changes:
+      breaking_changes:
+        - The new option ``prevent_known_fragments`` with default value being the value of ``keep_fragments`` allows to control whether fragments with names that already appeared in the past are ignored or not. The new behavior happens if ``keep_fragments=false``, and is less surprising to users (see https://github.com/ansible-community/antsibull-changelog/issues/46). Changelogs with ``keep_fragments=true``, like the ansible-base/ansible-core changelog, are not affected.
+      major_changes:
+        - Add support for reporting new playbooks and roles in collections.
+        - |
+          Add support for special changelog fragment sections which add new plugins and/or objects to the changelog for this version. This is mainly useful for ``test`` and ``filter`` plugins, and for ``playbook`` and ``role`` objects, which are not yet automatically detected and mentioned in ``changelogs/changelog.yaml`` or the generated RST changelog.
+
+          The format of these sections and their content is as follows::
+
+              ---
+              add plugin.filter:
+                - name: to_time_unit
+                  description: Converts a time expression to a given unit
+                - name: to_seconds
+                  description: Converts a time expression to seconds
+              add object.role:
+                - name: nginx
+                  description: The most awesome nginx installation role ever
+              add object.playbook:
+                - name: wipe_server
+                  description: Totally wipes a server
+
+          For every entry, a list of plugins (section ``add plugin.xxx``) or objects (section ``add object.xxx``) of the given type (``filter``, ``test`` for plugins, ``playbook``, ``role`` for objects) will be added. Every plugin or object has a short name as well as a short description. These fields correspond to the module/plugin name and the ``short_description`` field of the ``DOCUMENTATION`` block of modules and documentable plugins.
+      minor_changes:
+        - Add ``--update-existing`` option for ``antsibull-changelog release``, which allows to update the current release's release date and (if relevant) codename instead of simply reporting that the release already exists.
+    release_date: '2021-01-30'
+  0.10.0:
+    changes:
+      minor_changes:
+        - The new ``--cummulative-release`` option for ``antsibull-changelog release`` allows to add all plugins and objects to a release since whose ``version_added`` is later than the previous release version (or ancestor if there was no previous release), and at latest the current release version. This is needed for major releases of ``community.general`` and similarly organized collections.
+        - "Will now print a warning when a release is made where the no ``prelude_section_name`` section (default: ``release_summary``) appears."
+      bugfixes:
+        - Make sure that the plugin caching inside ansible-base/-core works without ``--use-ansible-doc``.
+    release_date: '2021-04-26'
+  0.11.0:
+    changes:
+      minor_changes:
+        - When using ansible-core 2.11 or newer, will now detect new roles with argument spec. We only consider the ``main`` entrypoint of roles.
+      bugfixes:
+        - When subdirectories of ``modules`` are used in ansible-base/ansible-core, the wrong module name was passed to ``ansible-doc`` when ``--use-ansible-doc`` was not used.
+    release_date: '2021-06-13'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -2,115 +2,156 @@ ancestor: null
 releases:
   0.1.0:
     changes:
-      release_summary: Initial release as antsibull-changelog. The Ansible Changelog Tool has originally been developed by @mattclay in `the ansible/ansible <https://github.com/ansible/ansible/blob/stable-2.9/packaging/release/changelogs/changelog.py>`_ repository for Ansible itself. It has been extended in `felixfontein/ansible-changelog <https://github.com/felixfontein/ansible-changelog/>`_ and `ansible-community/antsibull <https://github.com/ansible-community/antsibull/>`_ to work with collections, until it was moved to its current location `ansible-community/antsibull-changelog <https://github.com/ansible-community/antsibull-changelog/>`_.
+      release_summary: Initial release as antsibull-changelog. The Ansible Changelog
+        Tool has originally been developed by @mattclay in `the ansible/ansible <https://github.com/ansible/ansible/blob/stable-2.9/packaging/release/changelogs/changelog.py>`_
+        repository for Ansible itself. It has been extended in `felixfontein/ansible-changelog
+        <https://github.com/felixfontein/ansible-changelog/>`_ and `ansible-community/antsibull
+        <https://github.com/ansible-community/antsibull/>`_ to work with collections,
+        until it was moved to its current location `ansible-community/antsibull-changelog
+        <https://github.com/ansible-community/antsibull-changelog/>`_.
     release_date: '2020-05-30'
+  0.10.0:
+    changes:
+      bugfixes:
+      - Make sure that the plugin caching inside ansible-base/-core works without
+        ``--use-ansible-doc``.
+      minor_changes:
+      - The new ``--cummulative-release`` option for ``antsibull-changelog release``
+        allows to add all plugins and objects to a release since whose ``version_added``
+        is later than the previous release version (or ancestor if there was no previous
+        release), and at latest the current release version. This is needed for major
+        releases of ``community.general`` and similarly organized collections.
+      - 'Will now print a warning when a release is made where the no ``prelude_section_name``
+        section (default: ``release_summary``) appears.'
+    release_date: '2021-04-26'
+  0.11.0:
+    changes:
+      bugfixes:
+      - When subdirectories of ``modules`` are used in ansible-base/ansible-core,
+        the wrong module name was passed to ``ansible-doc`` when ``--use-ansible-doc``
+        was not used.
+      minor_changes:
+      - When using ansible-core 2.11 or newer, will now detect new roles with argument
+        spec. We only consider the ``main`` entrypoint of roles.
+    release_date: '2021-06-13'
   0.2.0:
     changes:
       minor_changes:
-        - Title generation improved (remove superfluous space).
-        - "``lint`` subcommand no longer requires specification whether it is run inside a collection or not (if usual indicators are absent)."
-        - Improve reStructuredText creation when new modules with and without namespace exist at the same time.
-        - Improve error handling.
-        - Fix internal API for ACD changelog generation (pruning and concatenation of changelogs).
-        - Use PyYAML C loader/dumper if available.
-        - Added more testing.
+      - Added more testing.
+      - Fix internal API for ACD changelog generation (pruning and concatenation of
+        changelogs).
+      - Improve error handling.
+      - Improve reStructuredText creation when new modules with and without namespace
+        exist at the same time.
+      - Title generation improved (remove superfluous space).
+      - Use PyYAML C loader/dumper if available.
+      - '``lint`` subcommand no longer requires specification whether it is run inside
+        a collection or not (if usual indicators are absent).'
     release_date: '2020-05-31'
   0.2.1:
     changes:
       bugfixes:
-        - Allow to enumerate plugins/modules with ansible-doc by specifying ``--use-ansible-doc``.
+      - Allow to enumerate plugins/modules with ansible-doc by specifying ``--use-ansible-doc``.
     release_date: '2020-06-10'
   0.3.0:
     changes:
       minor_changes:
-        - Changelog generator can be ran via ``python -m antsibull_changelog``.
-        - Allow to pass path to ansible-doc binary via ``--ansible-doc-bin``.
-        - Use ``ansible-doc`` instead of ``/path/to/checkout/bin/ansible-doc`` when being run in ansible-base checkouts.
+      - Allow to pass path to ansible-doc binary via ``--ansible-doc-bin``.
+      - Changelog generator can be ran via ``python -m antsibull_changelog``.
+      - Use ``ansible-doc`` instead of ``/path/to/checkout/bin/ansible-doc`` when
+        being run in ansible-base checkouts.
     release_date: '2020-06-10'
   0.3.1:
     changes:
       bugfixes:
-        - Improve error message when ``--is-collection`` is specified and ``changelogs/config.yaml`` cannot be found, or when the ``lint`` subcommand is used.
-        - Improve behavior when ``changelogs/config.yaml`` is not a dictionary, or does not contain ``sections``.
-        - Do not fail when ``changelogs/fragments`` does not exist. Simply assume there are no fragments in that case.
+      - Do not fail when ``changelogs/fragments`` does not exist. Simply assume there
+        are no fragments in that case.
+      - Improve behavior when ``changelogs/config.yaml`` is not a dictionary, or does
+        not contain ``sections``.
+      - Improve error message when ``--is-collection`` is specified and ``changelogs/config.yaml``
+        cannot be found, or when the ``lint`` subcommand is used.
     release_date: '2020-06-11'
   0.4.0:
     changes:
-      minor_changes:
-        - Allow to enable or disable flatmapping via ``config.yaml``.
       bugfixes:
-        - Fix bad module namespace detection when collection was symlinked into Ansible's collection search path. This also allows to add releases to collections which are not installed in a way that Ansible finds them.
+      - Fix bad module namespace detection when collection was symlinked into Ansible's
+        collection search path. This also allows to add releases to collections which
+        are not installed in a way that Ansible finds them.
+      minor_changes:
+      - Allow to enable or disable flatmapping via ``config.yaml``.
     release_date: '2020-06-22'
   0.5.0:
     changes:
       minor_changes:
-        - The internal changelog generator code got more flexible to help antsibull generate Ansible porting guides.
+      - The internal changelog generator code got more flexible to help antsibull
+        generate Ansible porting guides.
     release_date: '2020-06-28'
   0.6.0:
     changes:
       minor_changes:
-        - The config option ``archive_path_template`` allows to move fragments into an archive directory when ``keep_fragments`` is set to ``false``.
-        - New changelog configurations place the ``CHANGELOG.rst`` file by default in the top-level directory, and not in ``changelogs/``.
-        - The option ``use_fqcn`` (set to ``true`` in new configurations) allows to use FQCN for new plugins and modules.
+      - New changelog configurations place the ``CHANGELOG.rst`` file by default in
+        the top-level directory, and not in ``changelogs/``.
+      - The config option ``archive_path_template`` allows to move fragments into
+        an archive directory when ``keep_fragments`` is set to ``false``.
+      - The option ``use_fqcn`` (set to ``true`` in new configurations) allows to
+        use FQCN for new plugins and modules.
     release_date: '2020-07-12'
   0.7.0:
     changes:
       minor_changes:
-        - A new config option, ``ignore_other_fragment_extensions`` allows for configuring whether only ``.yaml`` and ``.yml`` files are used (as mandated by the ``ansible-test sanity --test changelog`` test). The default value for existing configurations is ``false``, and for new configurations ``true``.
-        - Refactoring changelog generation code to provide all preludes (release summaries) in changelog entries, and provide generic functionality to extract a grouped list of versions. These changes are mainly for the antsibull project.
-        - Allow to use semantic versioning also for Ansible-base with the ``use_semantic_versioning`` configuration setting.
+      - A new config option, ``ignore_other_fragment_extensions`` allows for configuring
+        whether only ``.yaml`` and ``.yml`` files are used (as mandated by the ``ansible-test
+        sanity --test changelog`` test). The default value for existing configurations
+        is ``false``, and for new configurations ``true``.
+      - Allow to use semantic versioning also for Ansible-base with the ``use_semantic_versioning``
+        configuration setting.
+      - Refactoring changelog generation code to provide all preludes (release summaries)
+        in changelog entries, and provide generic functionality to extract a grouped
+        list of versions. These changes are mainly for the antsibull project.
     release_date: '2020-07-26'
   0.8.0:
     changes:
       minor_changes:
-        - Allow to sanitize changelog data on load/save. This means that unknown information will be removed, and bad information will be stripped. This will be enabled in newly created changelog configs, but is disabled for backwards compatibility.
-        - Allow to not save a changelog on release when using API.
+      - Allow to not save a changelog on release when using API.
+      - Allow to sanitize changelog data on load/save. This means that unknown information
+        will be removed, and bad information will be stripped. This will be enabled
+        in newly created changelog configs, but is disabled for backwards compatibility.
     release_date: '2020-08-18'
   0.8.1:
     changes:
       bugfixes:
-        - Fixed error on generating changelogs when using the trivial section.
+      - Fixed error on generating changelogs when using the trivial section.
     release_date: '2020-08-27'
   0.9.0:
     changes:
       breaking_changes:
-        - The new option ``prevent_known_fragments`` with default value being the value of ``keep_fragments`` allows to control whether fragments with names that already appeared in the past are ignored or not. The new behavior happens if ``keep_fragments=false``, and is less surprising to users (see https://github.com/ansible-community/antsibull-changelog/issues/46). Changelogs with ``keep_fragments=true``, like the ansible-base/ansible-core changelog, are not affected.
+      - The new option ``prevent_known_fragments`` with default value being the value
+        of ``keep_fragments`` allows to control whether fragments with names that
+        already appeared in the past are ignored or not. The new behavior happens
+        if ``keep_fragments=false``, and is less surprising to users (see https://github.com/ansible-community/antsibull-changelog/issues/46).
+        Changelogs with ``keep_fragments=true``, like the ansible-base/ansible-core
+        changelog, are not affected.
       major_changes:
-        - Add support for reporting new playbooks and roles in collections.
-        - |
-          Add support for special changelog fragment sections which add new plugins and/or objects to the changelog for this version. This is mainly useful for ``test`` and ``filter`` plugins, and for ``playbook`` and ``role`` objects, which are not yet automatically detected and mentioned in ``changelogs/changelog.yaml`` or the generated RST changelog.
-
-          The format of these sections and their content is as follows::
-
-              ---
-              add plugin.filter:
-                - name: to_time_unit
-                  description: Converts a time expression to a given unit
-                - name: to_seconds
-                  description: Converts a time expression to seconds
-              add object.role:
-                - name: nginx
-                  description: The most awesome nginx installation role ever
-              add object.playbook:
-                - name: wipe_server
-                  description: Totally wipes a server
-
-          For every entry, a list of plugins (section ``add plugin.xxx``) or objects (section ``add object.xxx``) of the given type (``filter``, ``test`` for plugins, ``playbook``, ``role`` for objects) will be added. Every plugin or object has a short name as well as a short description. These fields correspond to the module/plugin name and the ``short_description`` field of the ``DOCUMENTATION`` block of modules and documentable plugins.
+      - Add support for reporting new playbooks and roles in collections.
+      - "Add support for special changelog fragment sections which add new plugins
+        and/or objects to the changelog for this version. This is mainly useful for
+        ``test`` and ``filter`` plugins, and for ``playbook`` and ``role`` objects,
+        which are not yet automatically detected and mentioned in ``changelogs/changelog.yaml``
+        or the generated RST changelog.\n\nThe format of these sections and their
+        content is as follows::\n\n    ---\n    add plugin.filter:\n      - name:
+        to_time_unit\n        description: Converts a time expression to a given unit\n
+        \     - name: to_seconds\n        description: Converts a time expression
+        to seconds\n    add object.role:\n      - name: nginx\n        description:
+        The most awesome nginx installation role ever\n    add object.playbook:\n
+        \     - name: wipe_server\n        description: Totally wipes a server\n\nFor
+        every entry, a list of plugins (section ``add plugin.xxx``) or objects (section
+        ``add object.xxx``) of the given type (``filter``, ``test`` for plugins, ``playbook``,
+        ``role`` for objects) will be added. Every plugin or object has a short name
+        as well as a short description. These fields correspond to the module/plugin
+        name and the ``short_description`` field of the ``DOCUMENTATION`` block of
+        modules and documentable plugins.\n"
       minor_changes:
-        - Add ``--update-existing`` option for ``antsibull-changelog release``, which allows to update the current release's release date and (if relevant) codename instead of simply reporting that the release already exists.
+      - Add ``--update-existing`` option for ``antsibull-changelog release``, which
+        allows to update the current release's release date and (if relevant) codename
+        instead of simply reporting that the release already exists.
     release_date: '2021-01-30'
-  0.10.0:
-    changes:
-      minor_changes:
-        - The new ``--cummulative-release`` option for ``antsibull-changelog release`` allows to add all plugins and objects to a release since whose ``version_added`` is later than the previous release version (or ancestor if there was no previous release), and at latest the current release version. This is needed for major releases of ``community.general`` and similarly organized collections.
-        - "Will now print a warning when a release is made where the no ``prelude_section_name`` section (default: ``release_summary``) appears."
-      bugfixes:
-        - Make sure that the plugin caching inside ansible-base/-core works without ``--use-ansible-doc``.
-    release_date: '2021-04-26'
-  0.11.0:
-    changes:
-      minor_changes:
-        - When using ansible-core 2.11 or newer, will now detect new roles with argument spec. We only consider the ``main`` entrypoint of roles.
-      bugfixes:
-        - When subdirectories of ``modules`` are used in ansible-base/ansible-core, the wrong module name was passed to ``ansible-doc`` when ``--use-ansible-doc`` was not used.
-    release_date: '2021-06-13'

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -26,4 +26,5 @@ sections:
   - Bugfixes
 - - known_issues
   - Known Issues
+use_semantic_versioning: true
 title: Ansible Changelog Tool

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,0 +1,28 @@
+changelog_filename_template: ../CHANGELOG.rst
+changelog_filename_version_depth: 0
+changes_file: changelog.yaml
+changes_format: combined
+keep_fragments: false
+mention_ancestor: true
+new_plugins_after_name: removed_features
+notesdir: fragments
+prelude_section_name: release_summary
+prelude_section_title: Release Summary
+sections:
+- - major_changes
+  - Major Changes
+- - minor_changes
+  - Minor Changes
+- - breaking_changes
+  - Breaking Changes / Porting Guide
+- - deprecated_features
+  - Deprecated Features
+- - removed_features
+  - Removed Features (previously deprecated)
+- - security_fixes
+  - Security Fixes
+- - bugfixes
+  - Bugfixes
+- - known_issues
+  - Known Issues
+title: Ansible Changelog Tool

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -2,6 +2,7 @@ changelog_filename_template: ../CHANGELOG.rst
 changelog_filename_version_depth: 0
 changes_file: changelog.yaml
 changes_format: combined
+is_other_project: true
 keep_fragments: false
 mention_ancestor: true
 new_plugins_after_name: removed_features

--- a/changelogs/fragments/other-projects.yml
+++ b/changelogs/fragments/other-projects.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "Support changelogs for other projects than ansible-core/-base and Ansible collections (https://github.com/ansible-community/antsibull-changelog/pull/60)."

--- a/changelogs/fragments/use_semantic_versioning.yml
+++ b/changelogs/fragments/use_semantic_versioning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Fix prerelease collapsing when ``use_semantic_versioning`` is set to ``true`` for ansible-core."

--- a/docs/changelog-configuration.rst
+++ b/docs/changelog-configuration.rst
@@ -1,6 +1,6 @@
-*****************************************************
-Configuration Settings for Changelogs for Collections
-*****************************************************
+**********************************************
+Configuration Settings for antsibull-changelog
+**********************************************
 
 .. contents::
    :local:
@@ -60,7 +60,7 @@ Determines whether ``changes_file`` contains only references to changelog fragme
 
 The default value is ``null``.
 
-Can be set to ``true`` or ``false`` explicitly to enable respectively disable flatmapping. Since flatmapping is disabled by default (except for ansible-base), this is effectively only needed for the big community collections ``community.general`` and ``community.network``.
+Can be set to ``true`` or ``false`` explicitly to enable respectively disable flatmapping. Since flatmapping is disabled by default (except for ansible-core), this is effectively only needed for the big community collections ``community.general`` and ``community.network``.
 
 When enabled, a plugin ``foo.bar.subdir.dir.plugin_name`` will be mentioned as ``plugin_name`` or ``foo.bar.plugin_name`` (if ``use_fqcn`` is ``true``), instead of as ``subdir.dir.plugin_name`` respectively ``foo.bar.subdir.dir.plugin_name``.
 
@@ -69,7 +69,7 @@ When enabled, a plugin ``foo.bar.subdir.dir.plugin_name`` will be mentioned as `
 
 The default value is ``false``.
 
-If set to ``true``, does not look for ``galaxy.yml`` and does not look for new Ansible objects (plugins, modules and roles). This allows the changelog generator to be used for projects which are not ansible-base/-core or an Ansible collection.
+If set to ``true``, does not look for ``galaxy.yml`` and does not look for new Ansible objects (plugins, modules and roles). This allows the changelog generator to be used for projects which are not ansible-core/-base or an Ansible collection.
 
 ``ignore_other_fragment_extensions`` (boolean)
 ----------------------------------------------
@@ -192,17 +192,17 @@ The default value is ``''`` (empty string).
 This setting is not used.
 
 
-Ansible-base specific options
-=============================
+Ansible-core/-base specific options
+===================================
 
-These options are only used for the changelog for ansible-base, i.e. in the ansible/ansible GitHub repository.
+These options are only used for the changelog for ansible-core, i.e. in the ansible/ansible GitHub repository.
 
 ``use_semantic_versioning`` (boolean)
 -------------------------------------
 
 The default value is ``false``.
 
-If set to ``true``, assumes that Ansible-base use semantic versioning instead of the classic Ansible version numbers. This is mainly relevant for pre-releases. If set to ``true``, ``release_tag_re`` and ``pre_release_tag_re`` are ignored.
+If set to ``true``, assumes that ansible-core use semantic versioning instead of the classic Ansible version numbers. This is mainly relevant for pre-releases. If set to ``true``, ``release_tag_re`` and ``pre_release_tag_re`` are ignored.
 
 ``release_tag_re`` (string)
 ---------------------------

--- a/docs/changelog-configuration.rst
+++ b/docs/changelog-configuration.rst
@@ -64,6 +64,13 @@ Can be set to ``true`` or ``false`` explicitly to enable respectively disable fl
 
 When enabled, a plugin ``foo.bar.subdir.dir.plugin_name`` will be mentioned as ``plugin_name`` or ``foo.bar.plugin_name`` (if ``use_fqcn`` is ``true``), instead of as ``subdir.dir.plugin_name`` respectively ``foo.bar.subdir.dir.plugin_name``.
 
+``is_other_project`` (boolean)
+------------------------------
+
+The default value is ``false``.
+
+If set to ``true``, does not look for ``galaxy.yml`` and does not look for new Ansible objects (plugins, modules and roles). This allows the changelog generator to be used for projects which are not ansible-base/-core or an Ansible collection.
+
 ``ignore_other_fragment_extensions`` (boolean)
 ----------------------------------------------
 

--- a/docs/changelog.yaml-format.md
+++ b/docs/changelog.yaml-format.md
@@ -11,7 +11,7 @@ You can use the `antsibull-lint changelog-yaml` tool included in the `antsibull 
 
     antsibull-lint changelog-yaml /path/to/changelog.yaml
 
-(This only works for `changelog.yaml` files in collections, not for the corresponding files in ansible-base, since ansible-base currently does not conform to semantic versioning.)
+(This only works for `changelog.yaml` files in collections, not for the corresponding files in ansible-core, since ansible-core currently does not conform to semantic versioning.)
 
 The tool does not output anything and exits with exit code 0 in case the file is OK, and outputs errors and exits with exit code 3 in case an error was found. Other exit codes indicate problems with the command line or during the execution of the linter.
 
@@ -25,7 +25,7 @@ At the top level, there are two entries:
 1. A string `ancestor`, which can also be `null` or omitted if the changelog has no ancestor.
 2. A dictionary `releases`, which maps version numbers to release information.
 
-If `ancestor` is a string, it must be an existing version of the collection which precedes all versions mentioned in this changelog. This is used when the changelog is truncated, for example when using release branches like for ansible-base. There, the `stable-2.10` branch's changelog contains only changelog entries for 2.10.x releases. Since the first 2.10.0b1 release contains all changes made to `devel` after `stable-2.9` was branched, the ancestor for the 2.10 changelog is `2.9.0b1`, the first release made after branching `stable-2.9`.
+If `ancestor` is a string, it must be an existing version of the collection which precedes all versions mentioned in this changelog. This is used when the changelog is truncated, for example when using release branches like for ansible-core. There, the `stable-2.10` branch's changelog contains only changelog entries for 2.10.x releases. Since the first 2.10.0b1 release contains all changes made to `devel` after `stable-2.9` was branched, the ancestor for the 2.10 changelog is `2.9.0b1`, the first release made after branching `stable-2.9`.
 
 The following shows the outline of a `changelog.yaml` file with four versions:
 
@@ -47,7 +47,7 @@ releases:
 For a release `x.y.z`, the `releases` dictionary contains an entry `x.y.z` mapping to another dictionary. That dictionary can have the following entries:
 
 1. `release_date`: a string in ISO format (`YYYY-MM-DD`) specifying on which date the release was made.
-1. `codename`: a string for the version's codename. Optional; mainly required for ansible-base.
+1. `codename`: a string for the version's codename. Optional; mainly required for ansible-core.
 1. `fragments`: a list of strings mentioning changelog fragment files used for this release. This is not used for compiling a changelog.
 1. `changes`: a dictionary containing all changes. See below.
 1. `modules`: a list of plugin dictionaries. See below.

--- a/docs/changelogs.rst
+++ b/docs/changelogs.rst
@@ -100,7 +100,7 @@ Changelog Fragment Categories
 
 This section describes the section categories created in the default config. You can change them, though this is strongly discouraged for collections which will be included in the Ansible Community Distribution.
 
-The categories are very similar to the ones in the `Ansible-case changelog fragments <https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to>`_. In fact, they are the same, except that there are three new categories: ``breaking_changes``, ``security_fixes`` and ``trivial``.
+The categories are the same as the ones in the `Ansible-case changelog fragments <https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to>`_.
 
 **NOTE:** The changelog generator automatically detects new modules and new plugins which are documentable (i.e. where you have ``DOCUMENTATION`` where ``version_added`` is there), so you do not need to create changelog entries for them.
 

--- a/docs/changelogs.rst
+++ b/docs/changelogs.rst
@@ -29,7 +29,7 @@ This is the directory which contains ``galaxy.yml``. This creates subdirectories
 #. ``always_refresh``: See :ref:`refreshing` on refreshing changelog fragments and/or plugin descriptions.
 #. ``archive_path_template``: If ``keep_fragments`` is set to ``false``, and ``archive_path_template`` is set, fragments will be copied into the directory denoted by ``archive_path_template`` instead of being deleted. The directory is created if it does not exist. The placeholder ``{version}`` can be used for the current collection version into which the fragment was included.
 
-For a description of all configuration settings, see the separate document `Configuration Settings for Changelogs for Collections <./changelog-configuration.rst>`_.
+For a description of all configuration settings, see the separate document `Configuration Settings for antsibull-changelog <./changelog-configuration.rst>`_.
 
 Validating changelog fragments
 ==============================

--- a/docs/changelogs.rst
+++ b/docs/changelogs.rst
@@ -25,7 +25,7 @@ This is the directory which contains ``galaxy.yml``. This creates subdirectories
 #. ``keep_fragments``: The default value ``false`` removes the fragment files after a release is done. If you prefer to keep fragment files for older releases, set this to ``true``. If you want to remove fragments after a release, but archive them in another directory, you can use the ``archive_path_template`` option in combination with ``keep_fragments: no`. See further below in the list for its usage.
 #. ``changelog_filename_template``: The default value ``../CHANGELOG.rst`` is relative to the ``changelogs/`` directory.
 #. ``use_fqcn``: The default value ``true`` uses FQCN when mentioning new plugins and modules.
-#. ``flatmap``: Setting to ``true`` or ``false`` explicitly enables resp. disables flatmapping. Since flatmapping is disabled by default (except for ansible-base), this is effectively only needed for the big community collections ``community.general`` and ``community.network``.
+#. ``flatmap``: Setting to ``true`` or ``false`` explicitly enables resp. disables flatmapping. Since flatmapping is disabled by default (except for ansible-core/-base), this is effectively only needed for the big community collections ``community.general`` and ``community.network``.
 #. ``always_refresh``: See :ref:`refreshing` on refreshing changelog fragments and/or plugin descriptions.
 #. ``archive_path_template``: If ``keep_fragments`` is set to ``false``, and ``archive_path_template`` is set, fragments will be copied into the directory denoted by ``archive_path_template`` instead of being deleted. The directory is created if it does not exist. The placeholder ``{version}`` can be used for the current collection version into which the fragment was included.
 
@@ -100,14 +100,14 @@ Changelog Fragment Categories
 
 This section describes the section categories created in the default config. You can change them, though this is strongly discouraged for collections which will be included in the Ansible Community Distribution.
 
-The categories are very similar to the ones in the `Ansible-base changelog fragments <https://docs.ansible.com/ansible/latest/community/development_process.html#changelogs-how-to>`_. In fact, they are the same, except that there are three new categories: ``breaking_changes``, ``security_fixes`` and ``trivial``.
+The categories are very similar to the ones in the `Ansible-case changelog fragments <https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to>`_. In fact, they are the same, except that there are three new categories: ``breaking_changes``, ``security_fixes`` and ``trivial``.
 
 **NOTE:** The changelog generator automatically detects new modules and new plugins which are documentable (i.e. where you have ``DOCUMENTATION`` where ``version_added`` is there), so you do not need to create changelog entries for them.
 
 The full list of categories is:
 
 **release_summary**
-  This is a special section: as opposed to a list of strings, it accepts one string. This string will be inserted at the top of the changelog entry for the current version, before any section. There can only be one fragment with a ``release_summary`` section. In Ansible-base, this is used for stating the release date and for linking to the porting guide (`example <https://github.com/ansible/ansible/blob/stable-2.9/changelogs/fragments/v2.9.0_summary.yaml>`_, `result <https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#id23>`_).
+  This is a special section: as opposed to a list of strings, it accepts one string. This string will be inserted at the top of the changelog entry for the current version, before any section. There can only be one fragment with a ``release_summary`` section. In ansible-core, this is used for stating the release date and for linking to the porting guide (`example <https://github.com/ansible/ansible/blob/stable-2.9/changelogs/fragments/v2.9.0_summary.yaml>`_, `result <https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#id23>`_).
 
 **breaking_changes**
   This (new) category should list all changes to features which absolutely require attention from users when upgrading, because an existing behavior is changed. This is mostly what Ansible's Porting Guide used to describe. This section should only appear in a initial major release (`x.0.0`) according to semantic versioning.
@@ -171,7 +171,7 @@ An example of how a fragment with ``release_summary`` could look like is ``chang
 Adding new Roles, Playbooks, Test and Filter Plugins
 ====================================================
 
-While ansible-base does not (yet) support roles, playbooks, and test and filter plugins as documentable plugins/objects, the changelog generator already has support for documenting new ones.
+While ansible-core does not (yet) support playbooks, test filter plugins, and filter plugins as documentable plugins/objects, the changelog generator already has support for documenting new ones.
 
 This works by using special sections in changelog fragments whose names start with "`add `"::
 

--- a/docs/other-projects.rst
+++ b/docs/other-projects.rst
@@ -1,0 +1,148 @@
+*****************************
+Changelogs for other projects
+*****************************
+
+.. contents::
+   :local:
+   :depth: 2
+
+The ``antsibull-changelog`` tool allows you to create and update changelogs for arbitrary projects, similar to the changelog of ansible-core or many Ansible collections which rely on antsibull-changelog.
+
+The following instructions assume that antsibull has been properly installed, for example via ``pip install antsibull-changelog``. This is the preferred way to install ``antsibull-changelog``.
+
+If you want to get the current ``main`` branch with not yet released changes, run ``pip install https://github.com/ansible-community/antsibull-changelog/archive/main.tar.gz``. If you cloned the git repository and want to run it from there with ``poetry``, ``antsibull-changelog`` has to be substituted with ``poetry run antsibull-changelog``.
+
+Bootstrapping changelogs for projects
+=====================================
+
+To set up ``antsibull-changelog``, run::
+
+    antsibull-changelog init --is-other-project /path/to/your/project
+
+This creates subdirectories ``changelogs/`` and ``changelogs/fragments/``, and a configuration file ``changelogs/config.yaml``. Adjust the configuration file to your needs. The settings of highest interest are:
+
+#. ``title``: This is by default ``Project``. Please replace this with the name of your project.
+#. ``use_semantic_versioning``: The default value ``true`` assumes that version numbers follow the `semantic versioning spec <https://semver.org/>`_. This mostly affects prerelease detection and version ordering.
+#. ``keep_fragments``: The default value ``false`` removes the fragment files after a release is done. If you prefer to keep fragment files for older releases, set this to ``true``. If you want to remove fragments after a release, but archive them in another directory, you can use the ``archive_path_template`` option in combination with ``keep_fragments: no`. See further below in the list for its usage.
+#. ``changelog_filename_template``: The default value ``../CHANGELOG.rst`` is relative to the ``changelogs/`` directory.
+#. ``always_refresh``: See :ref:`refreshing` on refreshing changelog fragments
+#. ``archive_path_template``: If ``keep_fragments`` is set to ``false``, and ``archive_path_template`` is set, fragments will be copied into the directory denoted by ``archive_path_template`` instead of being deleted. The directory is created if it does not exist. The placeholder ``{version}`` can be used for the current collection version into which the fragment was included.
+
+For a description of all configuration settings, see the separate document `Configuration Settings for antsibull-changelog <./changelog-configuration.rst>`_.
+
+Validating changelog fragments
+==============================
+
+If you want to do a basic syntax check of changelog fragments, you can run::
+
+    antsibull-changelog lint
+
+If you want to check a specific fragment, you can provide a path to it; otherwise, all fragments in ``changelogs/fragments/`` are checked. This can be used in CI to avoid contributors to check in invalid changelog fragments, or introduce new sections (by mistyping existing ones, or simply guessing wrong names).
+
+If ``antsibull-changelog lint`` produces no output on stdout, and exits with exit code 0, the changelog fragments are OK. If errors are found, they are reported by one line in stdout for each error in the format ``path/to/fragment:line:column:message``, and the program exits with exit code 3. Other exit codes indicate problems with the command line or during the execution of the linter.
+
+Releasing a new version of your project
+=======================================
+
+To release a new version of your project, you need to run::
+
+    antsibull-changelog release --version <version>
+
+inside your project's tree. You can also specify a release date with ``--date 2020-12-31``, if the default (today) is not what you want.
+
+When doing a release, the changelog generator will read all changelog fragments which are not already mentioned in the changelog, and include them in a new entry in ``changelogs/changelog.yaml``.
+
+After running ``antsibull-changelog release``, you should check ``changelogs/changelog.yaml`` and the generated reStructuredText file (by default ``CHANGELOG.rst``) in.
+
+.. _refreshing:
+
+Updating/Refreshing changelog.yaml
+==================================
+
+By default, the ``changelogs/changelog.yaml`` file is the main source of truth for antsibull-changelog. It is only modified when a new release is done, and in that case existing entries for other versions than the current one are not touched.
+
+If the main source of truth should be the fragments, the refreshing options or config has to be used.
+
+#. The ``always_refresh`` configuration is a string with one of the following values:
+    * ``none`` (default): equivalent to ``--refresh-fragments`` and ``--refresh`` not specified;
+    * ``full``: equivalent to ``--refresh-fragments with-archives`` specified, or alternatively ``--refresh``;
+    * a comma-separated list, where the following entries are supported:
+        * ``fragments``: equivalent to ``--refresh-fragments with-archives`` specified;
+        * ``fragments-without-archives``: equivalent to ``--refresh-fragments without-archives`` specified.
+
+#. The ``--refresh`` command line parameter is equivalent to ``--refresh-fragments with-archives``.
+
+#. ``--refresh-fragments``: if specified, the fragments for all versions will be recreated from the changelog fragment files. This is only possible if ``keep_fragments`` is ``true``, or fragment archives exist (see the ``archive_path_template`` option). Note that if not all fragments were archived or kept in the fragments directory, they will be **removed** from the changelog.
+    * ``with-archives`` (default): Uses both the archives and the current fragment directory to update the fragments.
+    * ``without-archives``: Uses only the current fragment directory to update the fragments. Fragments that have been moved to the archive and no longer exist in the fragment directory will vanish from the changelog.
+
+Changelog Fragment Categories
+=============================
+
+This section describes the section categories created in the default config. You can change them, though this is strongly discouraged for collections which will be included in the Ansible Community Distribution.
+
+The categories are very similar to the ones in the `Ansible-case changelog fragments <https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to>`_. In fact, they are the same, except that there are three new categories: ``breaking_changes``, ``security_fixes`` and ``trivial``.
+
+The full list of categories is:
+
+**release_summary**
+  This is a special section: as opposed to a list of strings, it accepts one string. This string will be inserted at the top of the changelog entry for the current version, before any section. There can only be one fragment with a ``release_summary`` section. In ansible-core, this is used for stating the release date and for linking to the porting guide (`example <https://github.com/ansible/ansible/blob/stable-2.9/changelogs/fragments/v2.9.0_summary.yaml>`_, `result <https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#id23>`_).
+
+**breaking_changes**
+  This (new) category should list all changes to features which absolutely require attention from users when upgrading, because an existing behavior is changed. This is mostly what Ansible's Porting Guide used to describe. This section should only appear in a initial major release (`x.0.0`) according to semantic versioning.
+
+**major_changes**
+  This category contains major changes to the collection. It should only contain a few items per major version, describing high-level changes. This section should not appear in patch releases according to semantic versioning.
+
+**minor_changes**
+  This category should mention all new features, like plugin or module options. This section should not appear in patch releases according to semantic versioning.
+
+**removed_features**
+  This category should mention all modules, plugins and features that have been removed in this release. This section should only appear in a initial major release (`x.0.0`) according to semantic versioning.
+
+**deprecated_features**
+  This category should contain all modules, plugins and features which have been deprecated and will be removed in a future release. This section should not appear in patch releases according to semantic versioning.
+
+**security_fixes**
+  This category should mention all security relevant fixes, including CVEs if available.
+
+**bugfixes**
+  This category should be a list of all bug fixes which fix a bug that was present in a previous version.
+
+**known_issues**
+  This category should mention known issues that are currently not fixed or will not be fixed.
+
+**trivial**
+  This category will **not be shown** in the changelog. It can be used to describe changes that are not touching user-facing code, like changes in tests. This is useful if every PR is required to have a changelog fragment.
+
+There are some special categories starting with "`add `"; please see the next section for details.
+
+Examples
+--------
+
+A guide on how to write changelog fragments can be found in the `Ansible docs <https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to>`_.
+
+Example of a regular changelog fragment::
+
+    bugfixes:
+      - docker_container - wait for removal of container if docker API returns early
+        (https://github.com/ansible/ansible/issues/65811).
+
+The filename in this case was ``changelogs/fragments/65854-docker_container-wait-for-removal.yml``, because this was implemented in `PR #65854 in ansible/ansible <https://github.com/ansible/ansible/pull/65854>`_.
+
+A fragment can also contain multiple sections, or multiple entries in one section::
+
+    deprecated_features:
+    - docker_container - the ``trust_image_content`` option will be removed. It has always been ignored by the module.
+    - docker_stack - the return values ``err`` and ``out`` have been deprecated. Use ``stdout`` and ``stderr`` from now on instead.
+
+    breaking_changes:
+    - "docker_container - no longer passes information on non-anonymous volumes or binds as ``Volumes`` to the Docker daemon. This increases compatibility with the ``docker`` CLI program. Note that if you specify ``volumes: strict`` in ``comparisons``, this could cause existing containers created with docker_container from Ansible 2.9 or earlier to restart."
+
+The ``release_summary`` section is special, in that it doesn't contain a list of strings, but a string, and that only one such entry can be shown in the changelog of a release. Usually for every release (pre-release or regular release), at most one fragment is added which contains a ``release_summary``, and this is only done by the person doing the release. The ``release_summary`` should include some global information on the release; for example, in `Ansible's changelog <https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#release-summary>`_, it always mentions the release date and links to the porting guide.
+
+An example of how a fragment with ``release_summary`` could look like is ``changelogs/fragments/0.2.0.yml`` from community.general::
+
+    release_summary: |
+      This is the first proper release of the ``community.general`` collection on 2020-06-20.
+      The changelog describes all changes made to the modules and plugins included in this collection since Ansible 2.9.0.

--- a/docs/other-projects.rst
+++ b/docs/other-projects.rst
@@ -26,7 +26,7 @@ This creates subdirectories ``changelogs/`` and ``changelogs/fragments/``, and a
 #. ``keep_fragments``: The default value ``false`` removes the fragment files after a release is done. If you prefer to keep fragment files for older releases, set this to ``true``. If you want to remove fragments after a release, but archive them in another directory, you can use the ``archive_path_template`` option in combination with ``keep_fragments: no`. See further below in the list for its usage.
 #. ``changelog_filename_template``: The default value ``../CHANGELOG.rst`` is relative to the ``changelogs/`` directory.
 #. ``always_refresh``: See :ref:`refreshing` on refreshing changelog fragments
-#. ``archive_path_template``: If ``keep_fragments`` is set to ``false``, and ``archive_path_template`` is set, fragments will be copied into the directory denoted by ``archive_path_template`` instead of being deleted. The directory is created if it does not exist. The placeholder ``{version}`` can be used for the current collection version into which the fragment was included.
+#. ``archive_path_template``: If ``keep_fragments`` is set to ``false``, and ``archive_path_template`` is set, fragments will be copied into the directory denoted by ``archive_path_template`` instead of being deleted. The directory is created if it does not exist. The placeholder ``{version}`` can be used for the current project version into which the fragment was included.
 
 For a description of all configuration settings, see the separate document `Configuration Settings for antsibull-changelog <./changelog-configuration.rst>`_.
 
@@ -79,9 +79,9 @@ If the main source of truth should be the fragments, the refreshing options or c
 Changelog Fragment Categories
 =============================
 
-This section describes the section categories created in the default config. You can change them, though this is strongly discouraged for collections which will be included in the Ansible Community Distribution.
+This section describes the section categories created in the default config. If you really want, you can change them.
 
-The categories are very similar to the ones in the `Ansible-case changelog fragments <https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to>`_. In fact, they are the same, except that there are three new categories: ``breaking_changes``, ``security_fixes`` and ``trivial``.
+The categories are the same as the ones in the `Ansible-case changelog fragments <https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs-how-to>`_.
 
 The full list of categories is:
 
@@ -92,7 +92,7 @@ The full list of categories is:
   This (new) category should list all changes to features which absolutely require attention from users when upgrading, because an existing behavior is changed. This is mostly what Ansible's Porting Guide used to describe. This section should only appear in a initial major release (`x.0.0`) according to semantic versioning.
 
 **major_changes**
-  This category contains major changes to the collection. It should only contain a few items per major version, describing high-level changes. This section should not appear in patch releases according to semantic versioning.
+  This category contains major changes to the project. It should only contain a few items per major version, describing high-level changes. This section should not appear in patch releases according to semantic versioning.
 
 **minor_changes**
   This category should mention all new features, like plugin or module options. This section should not appear in patch releases according to semantic versioning.
@@ -141,8 +141,7 @@ A fragment can also contain multiple sections, or multiple entries in one sectio
 
 The ``release_summary`` section is special, in that it doesn't contain a list of strings, but a string, and that only one such entry can be shown in the changelog of a release. Usually for every release (pre-release or regular release), at most one fragment is added which contains a ``release_summary``, and this is only done by the person doing the release. The ``release_summary`` should include some global information on the release; for example, in `Ansible's changelog <https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#release-summary>`_, it always mentions the release date and links to the porting guide.
 
-An example of how a fragment with ``release_summary`` could look like is ``changelogs/fragments/0.2.0.yml`` from community.general::
+An example of how a fragment with ``release_summary`` could look like::
 
     release_summary: |
-      This is the first proper release of the ``community.general`` collection on 2020-06-20.
-      The changelog describes all changes made to the modules and plugins included in this collection since Ansible 2.9.0.
+      This is the first proper release of ``antsibull-changelog`` on 2020-06-20.

--- a/tests/functional/fixtures.py
+++ b/tests/functional/fixtures.py
@@ -437,6 +437,17 @@ class CollectionChangelogEnvironment(ChangelogEnvironment):
         self._write(os.path.join(role_meta_dir, 'argument_spec.yml'), argspec)
 
 
+class OtherChangelogEnvironment(ChangelogEnvironment):
+    """
+    Other project changelog environment.
+    """
+
+    def __init__(self, base_path: pathlib.Path):
+        super().__init__(base_path,
+                         PathsConfig.force_other(base_dir=str(base_path)))
+        self.config.title = 'A Random Project'
+
+
 @pytest.fixture
 def ansible_changelog(tmp_path_factory) -> AnsibleChangelogEnvironment:
     """
@@ -479,3 +490,11 @@ def create_plugin(**parts):
         result.extend(['', '{part} = {data!r}'.format(part=part, data=data)])
 
     return '\n'.join(result)
+
+
+@pytest.fixture
+def other_changelog(tmp_path_factory) -> OtherChangelogEnvironment:
+    """
+    Fixture for Ansible changelog environment.
+    """
+    return OtherChangelogEnvironment(tmp_path_factory.mktemp('changelog-test'))

--- a/tests/functional/test_changelog_basic_other.py
+++ b/tests/functional/test_changelog_basic_other.py
@@ -25,6 +25,10 @@ def test_changelog_release_empty(  # pylint: disable=redefined-outer-name
     other_changelog.add_fragment_line(
         'trivial.yml', 'trivial', 'This should not show up in the changelog.')
 
+    # If we do not pass --version, will fail
+    assert other_changelog.run_tool('release', ['-v', '--date', '2020-01-02']) == 5
+
+    # If we pass --version, will succeed
     assert other_changelog.run_tool('release', ['-v', '--date', '2020-01-02', '--version', '1.0.0']) == 0
 
     diff = other_changelog.diff()

--- a/tests/functional/test_changelog_basic_other.py
+++ b/tests/functional/test_changelog_basic_other.py
@@ -17,6 +17,30 @@ from fixtures import create_plugin
 import antsibull_changelog.ansible  # noqa: F401; pylint: disable=unused-variable
 
 
+def test_changelog_init(  # pylint: disable=redefined-outer-name
+        other_changelog):  # noqa: F811
+    # If we do not specify --is-other-project, it should error out
+    assert other_changelog.run_tool('init', [other_changelog.paths.base_dir]) == 5
+
+    # If we do specify it, it just work
+    assert other_changelog.run_tool('init', [other_changelog.paths.base_dir, '--is-other-project']) == 0
+
+    diff = other_changelog.diff()
+    assert diff.added_dirs == ['changelogs', 'changelogs/fragments']
+    assert diff.added_files == ['changelogs/config.yaml']
+    assert diff.removed_dirs == []
+    assert diff.removed_files == []
+    assert diff.changed_files == []
+
+    config = diff.parse_yaml('changelogs/config.yaml')
+    assert config['notesdir'] == 'fragments'
+    assert config['changes_file'] == 'changelog.yaml'
+    assert config['changelog_filename_template'] == '../CHANGELOG.rst'
+    assert config['is_other_project'] is True
+    assert config['use_semantic_versioning'] is True
+    assert config['title'] == 'Project'
+
+
 def test_changelog_release_empty(  # pylint: disable=redefined-outer-name
         other_changelog):  # noqa: F811
     other_changelog.set_config(other_changelog.config)

--- a/tests/functional/test_changelog_basic_other.py
+++ b/tests/functional/test_changelog_basic_other.py
@@ -1,0 +1,537 @@
+# -*- coding: utf-8 -*-
+# Author: Felix Fontein <felix@fontein.de>
+# License: GPLv3+
+# Copyright: Ansible Project, 2020
+
+"""
+Test basic changelog functionality: Ansible collections
+"""
+
+import os
+
+import mock
+
+from fixtures import other_changelog  # noqa: F401; pylint: disable=unused-variable
+from fixtures import create_plugin
+
+import antsibull_changelog.ansible  # noqa: F401; pylint: disable=unused-variable
+
+
+def test_changelog_release_empty(  # pylint: disable=redefined-outer-name
+        other_changelog):  # noqa: F811
+    other_changelog.set_config(other_changelog.config)
+    other_changelog.add_fragment_line(
+        '1.0.0.yml', 'release_summary', 'This is the first proper release.')
+    other_changelog.add_fragment_line(
+        'trivial.yml', 'trivial', 'This should not show up in the changelog.')
+
+    assert other_changelog.run_tool('release', ['-v', '--date', '2020-01-02', '--version', '1.0.0']) == 0
+
+    diff = other_changelog.diff()
+    assert diff.added_dirs == []
+    assert diff.added_files == ['CHANGELOG.rst', 'changelogs/changelog.yaml']
+    assert diff.removed_dirs == []
+    assert diff.removed_files == ['changelogs/fragments/1.0.0.yml', 'changelogs/fragments/trivial.yml']
+    assert diff.changed_files == []
+
+    changelog = diff.parse_yaml('changelogs/changelog.yaml')
+    assert changelog['ancestor'] is None
+    assert list(changelog['releases']) == ['1.0.0']
+    assert changelog['releases']['1.0.0']['release_date'] == '2020-01-02'
+    assert changelog['releases']['1.0.0']['changes'] == {
+        'release_summary': 'This is the first proper release.'
+    }
+    assert changelog['releases']['1.0.0']['fragments'] == ['1.0.0.yml', 'trivial.yml']
+    assert 'modules' not in changelog['releases']['1.0.0']
+    assert 'plugins' not in changelog['releases']['1.0.0']
+    assert 'objects' not in changelog['releases']['1.0.0']
+    assert 'codename' not in changelog['releases']['1.0.0']
+
+    assert diff.file_contents['CHANGELOG.rst'].decode('utf-8') == (
+        r'''==============================
+A Random Project Release Notes
+==============================
+
+.. contents:: Topics
+
+
+v1.0.0
+======
+
+Release Summary
+---------------
+
+This is the first proper release.
+''')
+
+    assert other_changelog.run_tool('generate', ['-v', '--refresh']) == 0
+    assert other_changelog.diff().unchanged
+
+    assert other_changelog.run_tool('release', ['-v', '--codename', 'primetime', '--date', '2020-01-03', '--version', '1.0.0']) == 0
+    assert other_changelog.diff().unchanged
+
+    assert other_changelog.run_tool('release', ['-v', '--codename', 'primetime', '--date', '2020-01-03', '--version', '1.0.0', '--update-existing']) == 0
+    diff = other_changelog.diff()
+    assert diff.added_dirs == []
+    assert diff.added_files == []
+    assert diff.removed_dirs == []
+    assert diff.removed_files == []
+    assert diff.changed_files == ['CHANGELOG.rst', 'changelogs/changelog.yaml']
+
+    changelog = diff.parse_yaml('changelogs/changelog.yaml')
+    assert changelog['releases']['1.0.0']['release_date'] == '2020-01-03'
+    assert changelog['releases']['1.0.0']['codename'] == 'primetime'
+
+    assert diff.file_contents['CHANGELOG.rst'].decode('utf-8') == (
+        r'''==========================================
+A Random Project "primetime" Release Notes
+==========================================
+
+.. contents:: Topics
+
+
+v1.0.0
+======
+
+Release Summary
+---------------
+
+This is the first proper release.
+''')
+
+    # Version 1.1.0
+
+    assert other_changelog.run_tool('release', ['-v', '--date', '2020-02-29', '--version', '1.1.0']) == 0
+
+    diff = other_changelog.diff()
+    assert diff.added_dirs == []
+    assert diff.added_files == []
+    assert diff.removed_dirs == []
+    assert diff.removed_files == []
+    assert diff.changed_files == ['CHANGELOG.rst', 'changelogs/changelog.yaml']
+
+    changelog = diff.parse_yaml('changelogs/changelog.yaml')
+    assert changelog['ancestor'] is None
+    assert list(changelog['releases']) == ['1.0.0', '1.1.0']
+    assert changelog['releases']['1.1.0']['release_date'] == '2020-02-29'
+    assert 'changes' not in changelog['releases']['1.1.0']
+    assert 'fragments' not in changelog['releases']['1.1.0']
+    assert 'modules' not in changelog['releases']['1.1.0']
+    assert 'plugins' not in changelog['releases']['1.1.0']
+    assert 'objects' not in changelog['releases']['1.1.0']
+    assert 'codename' not in changelog['releases']['1.1.0']
+
+    assert diff.file_contents['CHANGELOG.rst'].decode('utf-8') == (
+        r'''==============================
+A Random Project Release Notes
+==============================
+
+.. contents:: Topics
+
+
+v1.1.0
+======
+
+v1.0.0
+======
+
+Release Summary
+---------------
+
+This is the first proper release.
+''')
+
+    assert other_changelog.run_tool('generate', ['-v', '--refresh']) == 0
+    assert other_changelog.diff().unchanged
+
+
+def test_changelog_release_simple(  # pylint: disable=redefined-outer-name
+        other_changelog):  # noqa: F811
+    other_changelog.config.changelog_filename_version_depth = 2
+    other_changelog.config.use_semantic_versioning = True
+    other_changelog.set_config(other_changelog.config)
+    other_changelog.add_fragment_line(
+        '1.0.0.yml', 'release_summary', 'This is the first proper release.')
+    other_changelog.add_fragment_line(
+        'test-new-option.yml', 'minor_changes', ['test - has a new option ``foo``.'])
+    other_changelog.add_fragment_line(
+        'baz-new-option.yaml', 'minor_changes',
+        ['baz lookup - no longer ignores the ``bar`` option.'])
+
+    # Lint fragments
+    assert other_changelog.run_tool('lint', ['-vv']) == 0
+
+    # Release
+    assert other_changelog.run_tool('release', ['-v', '--date', '2020-01-02', '--version', '1.0.0']) == 0
+
+    diff = other_changelog.diff()
+    assert diff.added_dirs == []
+    assert diff.added_files == ['CHANGELOG.rst', 'changelogs/changelog.yaml']
+    assert diff.removed_dirs == []
+    assert diff.removed_files == [
+        'changelogs/fragments/1.0.0.yml',
+        'changelogs/fragments/baz-new-option.yaml',
+        'changelogs/fragments/test-new-option.yml',
+    ]
+    assert diff.changed_files == []
+
+    changelog = diff.parse_yaml('changelogs/changelog.yaml')
+    assert changelog['ancestor'] is None
+    assert list(changelog['releases']) == ['1.0.0']
+    assert changelog['releases']['1.0.0']['release_date'] == '2020-01-02'
+    assert changelog['releases']['1.0.0']['changes'] == {
+        'release_summary': 'This is the first proper release.',
+        'minor_changes': [
+            'baz lookup - no longer ignores the ``bar`` option.',
+            'test - has a new option ``foo``.',
+        ],
+    }
+    assert changelog['releases']['1.0.0']['fragments'] == [
+        '1.0.0.yml',
+        'baz-new-option.yaml',
+        'test-new-option.yml',
+    ]
+    assert 'modules' not in changelog['releases']['1.0.0']
+    assert 'plugins' not in changelog['releases']['1.0.0']
+    assert 'codename' not in changelog['releases']['1.0.0']
+
+    assert diff.file_contents['CHANGELOG.rst'].decode('utf-8') == (
+        r'''==================================
+A Random Project 1.0 Release Notes
+==================================
+
+.. contents:: Topics
+
+
+v1.0.0
+======
+
+Release Summary
+---------------
+
+This is the first proper release.
+
+Minor Changes
+-------------
+
+- baz lookup - no longer ignores the ``bar`` option.
+- test - has a new option ``foo``.
+''')
+
+    # Check that regenerate doesn't change anything
+    assert other_changelog.run_tool('generate', ['-v']) == 0
+    assert other_changelog.diff().unchanged
+
+    # Add another fragment
+    other_changelog.add_fragment_line(
+        'test-new-fragment.yml', 'minor_changes', ['Another new fragment.'])
+
+    # Check that regenerate without --refresh* doesn't change anything
+    assert other_changelog.run_tool('generate', ['-v']) == 0
+    assert other_changelog.diff().unchanged
+
+    # Check that regenerate with --refresh-fragments does not change
+    assert other_changelog.run_tool('generate', ['-v', '--refresh-fragments']) == 0
+
+    diff = other_changelog.diff()
+    assert diff.unchanged
+
+    # Check that regenerate with --refresh-plugins does not change
+    assert other_changelog.run_tool('generate', ['-v', '--refresh-plugins']) == 0
+
+    diff = other_changelog.diff()
+    assert diff.unchanged
+
+    changelog = diff.parse_yaml('changelogs/changelog.yaml')
+    assert 'modules' not in changelog['releases']['1.0.0']
+    assert 'plugins' not in changelog['releases']['1.0.0']
+
+    assert diff.file_contents['CHANGELOG.rst'].decode('utf-8') == (
+        r'''==================================
+A Random Project 1.0 Release Notes
+==================================
+
+.. contents:: Topics
+
+
+v1.0.0
+======
+
+Release Summary
+---------------
+
+This is the first proper release.
+
+Minor Changes
+-------------
+
+- baz lookup - no longer ignores the ``bar`` option.
+- test - has a new option ``foo``.
+''')
+
+    # Prepare 1.1.0 beta 1
+    other_changelog.add_fragment_line(
+        '1.1.0-beta-1.yml', 'release_summary', 'Beta of 1.1.0.')
+
+    # Release 1.1.0-beta-1
+    assert other_changelog.run_tool('release', [
+        '-v',
+        '--date', '2020-02-14',
+        '--version', '1.1.0-beta-1',
+    ]) == 0
+
+    diff = other_changelog.diff()
+    assert diff.added_dirs == []
+    assert diff.added_files == []
+    assert diff.removed_dirs == []
+    assert diff.removed_files == [
+        'changelogs/fragments/1.1.0-beta-1.yml',
+        'changelogs/fragments/test-new-fragment.yml',
+    ]
+    assert diff.changed_files == ['CHANGELOG.rst', 'changelogs/changelog.yaml']
+
+    changelog = diff.parse_yaml('changelogs/changelog.yaml')
+    assert changelog['ancestor'] is None
+    assert list(changelog['releases']) == ['1.0.0', '1.1.0-beta-1']
+    assert changelog['releases']['1.1.0-beta-1']['release_date'] == '2020-02-14'
+    assert changelog['releases']['1.1.0-beta-1']['changes'] == {
+        'release_summary': 'Beta of 1.1.0.',
+        'minor_changes': [
+            'Another new fragment.',
+        ],
+    }
+    assert changelog['releases']['1.1.0-beta-1']['fragments'] == [
+        '1.1.0-beta-1.yml',
+        'test-new-fragment.yml',
+    ]
+    assert 'modules' not in changelog['releases']['1.1.0-beta-1']
+    assert 'plugins' not in changelog['releases']['1.1.0-beta-1']
+    assert 'objects' not in changelog['releases']['1.1.0-beta-1']
+    assert 'codename' not in changelog['releases']['1.1.0-beta-1']
+
+    assert diff.file_contents['CHANGELOG.rst'].decode('utf-8') == (
+        r'''==================================
+A Random Project 1.1 Release Notes
+==================================
+
+.. contents:: Topics
+
+
+v1.1.0-beta-1
+=============
+
+Release Summary
+---------------
+
+Beta of 1.1.0.
+
+Minor Changes
+-------------
+
+- Another new fragment.
+
+v1.0.0
+======
+
+Release Summary
+---------------
+
+This is the first proper release.
+
+Minor Changes
+-------------
+
+- baz lookup - no longer ignores the ``bar`` option.
+- test - has a new option ``foo``.
+''')
+
+    # Prepare 1.1.0
+    other_changelog.add_fragment_line(
+        '1.1.0.yml', 'release_summary', 'Final release of 1.1.0.')
+    other_changelog.add_fragment_line(
+        'minorchange.yml', 'minor_changes', ['A minor change.'])
+    other_changelog.add_fragment_line(
+        'bugfix.yml', 'bugfixes', ['A bugfix.'])
+
+    # Lint fragments
+    assert other_changelog.run_tool('lint', [
+        '-vvv',
+    ]) == 0
+
+    # Final release 1.1.0
+    assert other_changelog.run_tool('release', [
+        '-vvv',
+        '--date', '2020-02-29',
+        '--version', '1.1.0',
+    ]) == 0
+
+    diff = other_changelog.diff()
+    assert diff.added_dirs == []
+    assert diff.added_files == []
+    assert diff.removed_dirs == []
+    assert diff.removed_files == [
+        'changelogs/fragments/1.1.0.yml',
+        'changelogs/fragments/bugfix.yml',
+        'changelogs/fragments/minorchange.yml',
+    ]
+    assert diff.changed_files == ['CHANGELOG.rst', 'changelogs/changelog.yaml']
+
+    changelog = diff.parse_yaml('changelogs/changelog.yaml')
+    assert changelog['ancestor'] is None
+    assert list(changelog['releases']) == ['1.0.0', '1.1.0', '1.1.0-beta-1']
+    assert changelog['releases']['1.1.0']['release_date'] == '2020-02-29'
+    assert changelog['releases']['1.1.0']['changes'] == {
+        'release_summary': 'Final release of 1.1.0.',
+        'bugfixes': ['A bugfix.'],
+        'minor_changes': ['A minor change.'],
+    }
+    assert changelog['releases']['1.1.0']['fragments'] == [
+        '1.1.0.yml',
+        'bugfix.yml',
+        'minorchange.yml',
+    ]
+    assert 'modules' not in changelog['releases']['1.1.0']
+    assert 'plugins' not in changelog['releases']['1.1.0']
+    assert 'objects' not in changelog['releases']['1.1.0']
+    assert 'codename' not in changelog['releases']['1.1.0']
+
+    assert diff.file_contents['CHANGELOG.rst'].decode('utf-8') == (
+        r'''==================================
+A Random Project 1.1 Release Notes
+==================================
+
+.. contents:: Topics
+
+
+v1.1.0
+======
+
+Release Summary
+---------------
+
+Final release of 1.1.0.
+
+Minor Changes
+-------------
+
+- A minor change.
+- Another new fragment.
+
+Bugfixes
+--------
+
+- A bugfix.
+
+v1.0.0
+======
+
+Release Summary
+---------------
+
+This is the first proper release.
+
+Minor Changes
+-------------
+
+- baz lookup - no longer ignores the ``bar`` option.
+- test - has a new option ``foo``.
+''')
+
+    # Final release 1.1.0 - should not change
+    assert other_changelog.run_tool('release', [
+        '-vvv',
+        '--date', '2020-03-01',
+        '--version', '1.1.0',
+    ]) == 0
+
+    assert other_changelog.diff().unchanged
+
+    # Prepare 1.2.0
+    other_changelog.add_fragment_line(
+        '1.2.0.yml', 'release_summary', 'Release of 1.2.0.')
+
+    # Release 1.2.0
+    assert other_changelog.run_tool('release', [
+        '-vvv',
+        '--date', '2020-03-01',
+        '--version', '1.2.0',
+    ]) == 0
+
+    diff = other_changelog.diff()
+    assert diff.added_dirs == []
+    assert diff.added_files == []
+    assert diff.removed_dirs == []
+    assert diff.removed_files == ['changelogs/fragments/1.2.0.yml']
+    assert diff.changed_files == ['CHANGELOG.rst', 'changelogs/changelog.yaml']
+
+    changelog = diff.parse_yaml('changelogs/changelog.yaml')
+    assert changelog['ancestor'] is None
+    assert list(changelog['releases']) == ['1.0.0', '1.1.0', '1.1.0-beta-1', '1.2.0']
+    assert changelog['releases']['1.2.0']['release_date'] == '2020-03-01'
+    assert changelog['releases']['1.2.0']['changes'] == {
+        'release_summary': 'Release of 1.2.0.',
+    }
+    assert changelog['releases']['1.2.0']['fragments'] == ['1.2.0.yml']
+    assert 'modules' not in changelog['releases']['1.2.0']
+    assert 'plugins' not in changelog['releases']['1.2.0']
+    assert 'objects' not in changelog['releases']['1.2.0']
+    assert 'codename' not in changelog['releases']['1.2.0']
+
+    assert diff.file_contents['CHANGELOG.rst'].decode('utf-8') == (
+        r'''==================================
+A Random Project 1.2 Release Notes
+==================================
+
+.. contents:: Topics
+
+
+v1.2.0
+======
+
+Release Summary
+---------------
+
+Release of 1.2.0.
+
+v1.1.0
+======
+
+Release Summary
+---------------
+
+Final release of 1.1.0.
+
+Minor Changes
+-------------
+
+- A minor change.
+- Another new fragment.
+
+Bugfixes
+--------
+
+- A bugfix.
+
+v1.0.0
+======
+
+Release Summary
+---------------
+
+This is the first proper release.
+
+Minor Changes
+-------------
+
+- baz lookup - no longer ignores the ``bar`` option.
+- test - has a new option ``foo``.
+''')
+
+    # Release 1.2.0 - should not change
+    assert other_changelog.run_tool('release', [
+        '-vvv',
+        '--date', '2020-03-02',
+        '--version', '1.2.0',
+    ]) == 0
+
+    assert other_changelog.diff().unchanged


### PR DESCRIPTION
This adds basic support for other projects than ansible-core and Ansible collections. Right now you have to create `changelogs/config.yaml` manually, and make sure that it contains `is_other_project: true`. Besides that, the basic functionality seems to work.

Eventually fixes #59.