### PR TITLE
Allow to use packaging.version.Version for linting changelog.yaml files

### DIFF
--- a/changelogs/fragments/0.14.0.yml
+++ b/changelogs/fragments/0.14.0.yml
@@ -1,0 +1,1 @@
+release_summary: Feature release with internal changes needed for antsibull.

--- a/changelogs/fragments/changelog-linting.yml
+++ b/changelogs/fragments/changelog-linting.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "The internal ``changelog.yaml`` linting API allows to use ``packaging.version.Version`` for version numbers instead of semantic versioning (https://github.com/ansible-community/antsibull-changelog/pull/73)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "antsibull-changelog"
-version = "0.13.0"
+version = "0.14.0"
 description = "Changelog tool for Ansible-base and Ansible collections"
 authors = ["Felix Fontein <felix@fontein.de>", "Toshio Kuratomi <a.badger@gmail.com>", "Matt Clay <matt@mystile.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Needed to fix broken CI in antsibull (due to beta release).