### PR TITLE
Add lint-changelog-yaml command

### DIFF
--- a/.github/workflows/changelog-lint.yml
+++ b/.github/workflows/changelog-lint.yml
@@ -35,15 +35,15 @@ jobs:
 
       - name: antsibull-changelog lint-changelog-yaml (community.general changelog)
         run: |
-          poetry run coverage run -p --source antsibull -m antsibull_changelog.cli lint-changelog-yaml community.general/changelogs/changelog.yaml
+          poetry run coverage run -p --source antsibull_changelog -m antsibull_changelog.cli lint-changelog-yaml community.general/changelogs/changelog.yaml
 
       - name: antsibull-changelog lint-changelog-yaml (own changelog)
         run: |
-          poetry run coverage run -p --source antsibull -m antsibull_changelog.cli lint-changelog-yaml --no-semantic-versioning changelogs/changelog.yaml
+          poetry run coverage run -p --source antsibull_changelog -m antsibull_changelog.cli lint-changelog-yaml --no-semantic-versioning changelogs/changelog.yaml
 
       - name: antsibull-changelog lint (own changelog fragments)
         run: |
-          poetry run coverage run -p --source antsibull -m antsibull_changelog.cli lint
+          poetry run coverage run -p --source antsibull_changelog -m antsibull_changelog.cli lint
 
       - name: Combine and upload coverage stats
         run: |

--- a/.github/workflows/changelog-lint.yml
+++ b/.github/workflows/changelog-lint.yml
@@ -1,0 +1,53 @@
+name: Test antsibull-changelog lint-changelog-yaml subcommand
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Run once per week (Friday at 06:00 UTC)
+  schedule:
+    - cron: '0 6 * * 5'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          poetry install
+
+      - name: Check out community.general's stable-4 branch
+        uses: actions/checkout@v2
+        with:
+          repository: ansible-collections/community.general
+          ref: stable-4
+          path: community.general
+
+      - name: antsibull-changelog lint-changelog-yaml (community.general changelog)
+        run: |
+          poetry run coverage run -p --source antsibull -m antsibull_changelog.cli lint-changelog-yaml community.general/changelogs/changelog.yaml
+
+      - name: antsibull-changelog lint-changelog-yaml (own changelog)
+        run: |
+          poetry run coverage run -p --source antsibull -m antsibull_changelog.cli lint-changelog-yaml --no-semantic-versioning changelogs/changelog.yaml
+
+      - name: antsibull-changelog lint (own changelog fragments)
+        run: |
+          poetry run coverage run -p --source antsibull -m antsibull_changelog.cli lint
+
+      - name: Combine and upload coverage stats
+        run: |
+          poetry run coverage combine .coverage.*
+          poetry run coverage report
+          poetry run coverage xml -i
+          poetry run codecov

--- a/changelogs/fragments/76-lint-changelog-yaml.yml
+++ b/changelogs/fragments/76-lint-changelog-yaml.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "Add ``changelogs/changelog.yaml`` file format linting subcommand that was previously part of antsibull-lint (https://github.com/ansible-community/antsibull-changelog/pull/76)."
+  - "Add ``changelogs/changelog.yaml`` file format linting subcommand that was previously part of antsibull-lint (https://github.com/ansible-community/antsibull-changelog/pull/76, https://github.com/ansible-community/antsibull/issues/410)."

--- a/changelogs/fragments/76-lint-changelog-yaml.yml
+++ b/changelogs/fragments/76-lint-changelog-yaml.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add ``changelogs/changelog.yaml`` file format linting subcommand that was previously part of antsibull-lint (https://github.com/ansible-community/antsibull-changelog/pull/76)."

--- a/docs/changelog.yaml-format.md
+++ b/docs/changelog.yaml-format.md
@@ -7,11 +7,11 @@ The format is similar to the `.changes.yaml` file used internally by Ansible unt
 
 Please remember that collection versions **must** use [semantic versioning](https://semver.org/) if included in the Ansible package or RedHat's Automation Hub.
 
-You can use the `antsibull-lint changelog-yaml` tool included in the `antsibull package <https://pypi.org/project/antsibull/>`_ to validate these files:
+You can use the `antsibull-changelog lint-changelog-yaml` tool included in the `antsibull-changelog package <https://pypi.org/project/antsibull-changelog/>`_ to validate these files:
 
-    antsibull-lint changelog-yaml /path/to/changelog.yaml
+    antsibull-changelog lint-changelog-yaml /path/to/changelog.yaml
 
-(This only works for `changelog.yaml` files in collections, not for the corresponding files in ansible-core, since ansible-core currently does not conform to semantic versioning.)
+(For `changelog.yaml` files of projects that do not conform to semantic versioning use the `--no-semantic-versioning` parameter.)
 
 The tool does not output anything and exits with exit code 0 in case the file is OK, and outputs errors and exits with exit code 3 in case an error was found. Other exit codes indicate problems with the command line or during the execution of the linter.
 

--- a/src/antsibull_changelog/lint.py
+++ b/src/antsibull_changelog/lint.py
@@ -254,7 +254,8 @@ class ChangelogYamlLinter:
         try:
             changelog_yaml = load_yaml(self.path)
         except Exception as exc:  # pylint: disable=broad-except
-            self.errors.append((self.path, 0, 0, 'error while parsing YAML: {0}'.format(exc)))
+            self.errors.append(
+                (self.path, 0, 0, 'error while parsing YAML: {0}'.format(exc).replace('\n', ' ')))
             return self.errors
 
         ancestor_str = changelog_yaml.get('ancestor')


### PR DESCRIPTION
First step to deprecating antsibull-lint; see https://github.com/ansible-community/antsibull/issues/410.