### PR TITLE
Allow to extract version for Python's poetry based projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then you can install antsibull-changelog with `pip install -e .`.
 
 First update the `version` entry in `pyproject.toml`. Then generate the changelog:
 
-    antsibull-changelog release --version <version-number>
+    antsibull-changelog release
 
 Then build the build artefact:
 

--- a/changelogs/fragments/80-pyproject-poetry.yml
+++ b/changelogs/fragments/80-pyproject-poetry.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Allow to extract other project versions for Python poetry projects from ``pyproject.toml`` (https://github.com/ansible-community/antsibull-changelog/pull/80)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ mypy = "*"
 mock = "*"
 types-docutils = "*"
 types-PyYAML = "*"
+types-toml = "*"
 
 [tool.isort]
 line_length = 100


### PR DESCRIPTION
This simplifies the release process of antsibull-changelog, antsibull-core, antsibull-docs, antsibull, and any other project that uses this changelog generator that's based on Python's poetry, since the `--version` parameter no longer needs to be used.