### PR TITLE
Make newer rstcheck versions as compatible

### DIFF
--- a/changelogs/fragments/81-rstcheck.yml
+++ b/changelogs/fragments/81-rstcheck.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Mark rstcheck 4.x and 5.x as compatible (https://github.com/ansible-community/antsibull-changelog/pull/81)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ python = "^3.6.0"
 packaging = "*"
 semantic_version = "*"
 docutils = "*"
-rstcheck = "^3"
+rstcheck = ">= 3.0.0, < 6.0.0"
 PyYAML = "*"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Versions 4.x and 5.x are compatible as well. With 6.0.0 rstcheck was split into a library and CLI program (https://github.com/rstcheck/rstcheck/issues/104#issuecomment-1140295726). Switching the dependency from rstcheck to rstcheck-core will be a breaking change.