### PR TITLE
Fix rstcheck-core support

### DIFF
--- a/.github/workflows/changelog-lint.yml
+++ b/.github/workflows/changelog-lint.yml
@@ -15,15 +15,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
+          sed -i -e 's/^python = .*/python = "^3.10"/' pyproject.toml
           poetry install
 
       - name: Check out community.general's stable-4 branch

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
+          sed -i -e 's/^python = .*/python = "^${{ matrix.python-version }}"/' pyproject.toml
           poetry install
       - name: Test with pytest and upload coverage stats
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,10 @@ python = "^3.6.0"
 packaging = "*"
 semantic_version = "*"
 docutils = "*"
-rstcheck = ">= 3.0.0, < 7.0.0"
+rstcheck = [
+    {version = ">= 3.0.0, < 4.0.0", python = "~3.6"},
+    {version = ">= 3.0.0, < 7.0.0", python = "^3.7"}
+]
 PyYAML = "*"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ python = "^3.6.0"
 packaging = "*"
 semantic_version = "*"
 docutils = "*"
-rstcheck = ">= 3.0.0, < 4.0.0"
+rstcheck = ">= 3.0.0, < 7.0.0"
 PyYAML = "*"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,7 @@ python = "^3.6.0"
 packaging = "*"
 semantic_version = "*"
 docutils = "*"
-rstcheck = [
-    {version = ">= 3.0.0, < 4.0.0", python = "~3.6"},
-    {version = ">= 3.0.0, < 7.0.0", python = "^3.7"}
-]
+rstcheck = ">= 3.0.0, < 4.0.0"
 PyYAML = "*"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ mock = "*"
 types-docutils = "*"
 types-PyYAML = "*"
 types-toml = "*"
+# Needed for TypedDict in rstcheck-core stubs
+typing-extensions = {version = ">=3.7.4", python = "<3.8"}
 
 [tool.isort]
 line_length = 100

--- a/src/antsibull_changelog/plugins.py
+++ b/src/antsibull_changelog/plugins.py
@@ -100,7 +100,7 @@ def extract_namespace(paths: PathsConfig, collection_name: Optional[str], filena
             break
         if last not in ('', '.', '..'):
             namespace_list.insert(0, last)
-    return'.'.join(namespace_list)
+    return '.'.join(namespace_list)
 
 
 def jsondoc_to_metadata(paths: PathsConfig,  # pylint: disable=too-many-arguments

--- a/src/antsibull_changelog/rstcheck.py
+++ b/src/antsibull_changelog/rstcheck.py
@@ -43,7 +43,7 @@ def check_rst_content(content: str, filename: t.Optional[str] = None
             core_results = rstcheck_core.checker.check_file(pathlib.Path(rst_path), config)
             return [(result['line_number'], 0, result['message']) for result in core_results]
     else:
-        results = rstcheck.check(
+        results = rstcheck.check(  # pylint: disable=no-member
             content,
             filename=filename,
             report_level=docutils.utils.Reporter.WARNING_LEVEL,

--- a/src/antsibull_changelog/rstcheck.py
+++ b/src/antsibull_changelog/rstcheck.py
@@ -41,7 +41,7 @@ def check_rst_content(content: str, filename: t.Optional[str] = None
                 report_level=rstcheck_core.config.ReportLevel.WARNING,
             )
             core_results = rstcheck_core.checker.check_file(pathlib.Path(rst_path), config)
-            return [(result.line_number, 0, result.message) for result in core_results]
+            return [(result['line_number'], 0, result['message']) for result in core_results]
     else:
         results = rstcheck.check(
             content,

--- a/stubs/rstcheck_core/types.pyi
+++ b/stubs/rstcheck_core/types.pyi
@@ -3,8 +3,13 @@ import pathlib
 
 from typing import Literal, Union
 
+try:
+    from typing import TypedDict
+except ImportError:
+    from typing_extensions import TypedDict
 
-class LintError:
+
+class LintError(TypedDict):
     source_origin: Union[pathlib.Path, Literal["<string>"], Literal["<stdin>"]]
     line_number: int
     message: str


### PR DESCRIPTION
There's a bug that's unfortunately not caught in the tests since these run with an older rstcheck version. For some reason, poetry insists on installing rstcheck 3.5.0. This is because `poetry update` tries to install versions of the dependency that support **all** Python versions that antsibull-changelog also supports, i.e. 3.6+, and only rstcheck < 4.0.0 does that.