### PR TITLE
Drop support for Python 3.6, 3.7, and 3.8

### DIFF
--- a/.github/workflows/pythonlinters.yml
+++ b/.github/workflows/pythonlinters.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.10'
+          - '3.11'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pythontests.yml
+++ b/.github/workflows/pythontests.yml
@@ -20,16 +20,10 @@ on:
 
 jobs:
   build:
-    runs-on: >-
-      ${{ contains(fromJson(
-          '["3.6"]'
-      ), matrix.python-version) && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
-          - 3.6
-          - 3.7
-          - 3.8
           - 3.9
           - '3.10'
           - '3.11'

--- a/changelogs/fragments/python.yml
+++ b/changelogs/fragments/python.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - "Drop support for Python 3.6, 3.7, and 3.8 (https://github.com/ansible-community/antsibull-changelog/pull/93)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 antsibull-changelog = "antsibull_changelog.cli:main"
 
 [tool.poetry.dependencies]
-python = "^3.6.0"
+python = "^3.9.0"
 packaging = "*"
 semantic_version = "*"
 docutils = "*"


### PR DESCRIPTION
I don't think we still need to support those. I'm planning to make a new release with only this (especially since there doesn't seem to be anything else coming up).