### PR TITLE
Truncate file after replacing version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -187,6 +187,7 @@ def _repl_version(session: nox.Session, new_version: str):
             if line.startswith("version = "):
                 line = f'version = "{new_version}"\n'
             fp.write(line)
+        fp.truncate()
 
 
 def check_no_modifications(session: nox.Session) -> None:


### PR DESCRIPTION
When I tried to prepare a release with `nox -e bump -- 0.20.0 "..."`, I got
```
nox > Running session bump
nox > Creating virtual environment (virtualenv) using python in .nox/bump
nox > git status --porcelain=v1 --untracked=normal
nox > python -m pip install antsibull-changelog 'tomli ; python_version < '"'"'3.11'"'"'' -U
nox > python -c 'import yaml ; print(yaml.dump(dict(release_summary='"'"'Bugfix and maintenance release using a new build system.'"'"')))'
nox > git add pyproject.toml changelogs/fragments/0.20.0.yml
nox > git commit -m 'Prepare 0.20.0.'
[main f5b0f03] Prepare 0.20.0.
 2 files changed, 6 insertions(+), 1 deletion(-)
 create mode 100644 changelogs/fragments/0.20.0.yml
nox > antsibull-changelog release
ERROR: Uncaught exception. Run with -v to see traceback.
nox > Command antsibull-changelog release failed with exit code 1
nox > Session bump failed.
```
Running antsibull-changelog with more verbosity resulted in:
```
$ antsibull-changelog release -v
Traceback (most recent call last):
  File ".../antsibull-changelog/src/antsibull_changelog/cli.py", line 262, in run
    return arguments.func(arguments)
  File ".../antsibull-changelog/src/antsibull_changelog/cli.py", line 535, in command_release
    version, codename = _get_version_and_codename(paths, config, collection_details, args)
  File ".../antsibull-changelog/src/antsibull_changelog/cli.py", line 510, in _get_version_and_codename
    version = _get_project_version(paths)
  File ".../antsibull-changelog/src/antsibull_changelog/cli.py", line 470, in _get_project_version
    return _get_pyproject_toml_version(project_toml_path)
  File ".../antsibull-changelog/src/antsibull_changelog/cli.py", line 437, in _get_pyproject_toml_version
    data = load_toml(project_toml_path)
  File ".../antsibull-changelog/src/antsibull_changelog/toml.py", line 50, in load_toml
    return tomli.loads(f.read())
  File "/usr/lib/python3.10/site-packages/tomli/_parser.py", line 102, in loads
    pos = key_value_rule(src, pos, out, header, parse_float)
  File "/usr/lib/python3.10/site-packages/tomli/_parser.py", line 326, in key_value_rule
    pos, key, value = parse_key_value_pair(src, pos, parse_float)
  File "/usr/lib/python3.10/site-packages/tomli/_parser.py", line 366, in parse_key_value_pair
    raise suffixed_err(src, pos, "Expected '=' after a key in a key/value pair")
tomli.TOMLDecodeError: Expected '=' after a key in a key/value pair (at line 98, column 2)
```
The pyproject.toml file had extra
```
s",
]
```
content appended, due to the file being shortened, but not truncated.

(Is anyone else reminded of the image cropper bugs published recently?)