### PR TITLE
Fix release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ To run specific tests:
    * Creates `changelogs/fragments/<version>.yml` with a `release_summary` section.
    * Runs `antsibull-changelog release` and adds the changed files to git.
    * Commits with message `Release <version>.` and runs `git tag -a -m 'antsibull <version>' <version>`.
+   * Runs `hatch build`.
 2. Run `git push` to the appropriate remotes.
 3. Once CI passes on GitHub, run `nox -e publish`. This:
    * Runs `hatch publish`;
-   * Runs `git push --follow-tags`;
    * Bumps the version to `<version>.post0`;
    * Adds the changed file to git and run `git commit -m 'Post-release version bump.'`;
 4. Run `git push --follow-tags` to the appropriate remotes and create a GitHub release.

--- a/noxfile.py
+++ b/noxfile.py
@@ -220,7 +220,7 @@ def bump(session: nox.Session):
             session.error(
                 f"Either {fragment_file} must already exist, or two positional arguments must be provided."
             )
-    install(session, "antsibull-changelog", "tomli ; python_version < '3.11'")
+    install(session, ".", "hatch", "tomli ; python_version < '3.11'")
     _repl_version(session, version)
     if len(session.posargs) > 1:
         fragment = session.run(
@@ -254,6 +254,7 @@ def bump(session: nox.Session):
         version,
         external=True,
     )
+    session.run("hatch", "build")
 
 
 @nox.session
@@ -261,8 +262,7 @@ def publish(session: nox.Session):
     check_no_modifications(session)
     install(session, "hatch")
     session.run("hatch", "publish", *session.posargs)
-    session.run("git", "push", "--follow-tags")
     version = session.run("hatch", "version", silent=True).strip()
     _repl_version(session, f"{version}.post0")
-    session.run("git", "add", "pyproject.toml")
+    session.run("git", "add", "pyproject.toml", external=True)
     session.run("git", "commit", "-m", "Post-release version bump.", external=True)


### PR DESCRIPTION
While trying to release 0.20.0 I found some problems with the release process:

1. missing `external=True` generates some warnings
2. `hatch build` is not called, which results in `hatch publish` not publishing anything (it worked for me in antsibull-docs-parser because I probably ran it before myself)
3. `tox -e publish` pushes the tag even if nothing was published, and in my case pushes it to the wrong remote, even though the docs say you have to do it manually. That's why I'm removing it here.
4. It was using the wrong message for the tag :)
5. Let's use the to be released version of antsibull-changelog to create the changelog, instead of the one that was previously released.

I'll create identical PRs (without the last two points) in the other repos.