### PR TITLE
tests: use unittest.mock instead of mock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ antsibull-changelog = "antsibull_changelog.cli:main"
 
 [project.optional-dependencies]
 test = [
-    "mock",
     "pytest",
     "pytest-cov",
     "pytest-error-for-skips",

--- a/tests/functional/test_changelog_archive.py
+++ b/tests/functional/test_changelog_archive.py
@@ -10,8 +10,8 @@ Test changelog functionality: keep_fragments and archiving
 from __future__ import annotations
 
 import os
+from unittest import mock
 
-import mock
 from fixtures import collection_changelog  # noqa: F401; pylint: disable=unused-variable
 from fixtures import create_plugin
 

--- a/tests/functional/test_changelog_basic_ansible.py
+++ b/tests/functional/test_changelog_basic_ansible.py
@@ -10,8 +10,8 @@ Test basic changelog functionality: Ansible Base 2.10+
 from __future__ import annotations
 
 import os
+from unittest import mock
 
-import mock
 from fixtures import ansible_changelog  # noqa: F401; pylint: disable=unused-variable
 from fixtures import create_plugin
 

--- a/tests/functional/test_changelog_basic_ansible_classic.py
+++ b/tests/functional/test_changelog_basic_ansible_classic.py
@@ -10,8 +10,8 @@ Test basic changelog functionality: Ansible 2.9 format.
 from __future__ import annotations
 
 import os
+from unittest import mock
 
-import mock
 from fixtures import ansible_changelog  # noqa: F401; pylint: disable=unused-variable
 from fixtures import create_plugin
 

--- a/tests/functional/test_changelog_basic_collection.py
+++ b/tests/functional/test_changelog_basic_collection.py
@@ -10,8 +10,8 @@ Test basic changelog functionality: Ansible collections
 from __future__ import annotations
 
 import os
+from unittest import mock
 
-import mock
 from fixtures import collection_changelog  # noqa: F401; pylint: disable=unused-variable
 from fixtures import create_plugin
 

--- a/tests/functional/test_changelog_basic_lint.py
+++ b/tests/functional/test_changelog_basic_lint.py
@@ -10,8 +10,8 @@ Test basic changelog functionality: lint fragments
 from __future__ import annotations
 
 import os
+from unittest import mock
 
-import mock
 from fixtures import collection_changelog  # noqa: F401; pylint: disable=unused-variable
 from fixtures import create_plugin
 

--- a/tests/functional/test_changelog_basic_other.py
+++ b/tests/functional/test_changelog_basic_other.py
@@ -11,8 +11,8 @@ from __future__ import annotations
 
 import json
 import os
+from unittest import mock
 
-import mock
 from fixtures import other_changelog  # noqa: F401; pylint: disable=unused-variable
 from fixtures import create_plugin
 


### PR DESCRIPTION
The `mock` package is a backport of unittest.mock. It is not needed for
newer Pythons.
