### PR TITLE
CI: remove in valid GHA parameters, make pyre work in CI

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          working-directory: antsibull-changelog
+          directory: antsibull-changelog
   nox-integration:
     runs-on: ubuntu-latest
     defaults:
@@ -82,4 +82,4 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v3
         with:
-          working-directory: antsibull-changelog
+          directory: antsibull-changelog

--- a/noxfile.py
+++ b/noxfile.py
@@ -152,7 +152,8 @@ def codeqa(session: nox.Session):
 
 @nox.session
 def typing(session: nox.Session):
-    install(session, ".[typing]", editable=True)
+    # pyre does not work when we don't install ourself in editable mode 🙄.
+    install(session, "-e", ".[typing]")
     session.run("mypy", "src/antsibull_changelog")
 
     purelib = session.run(


### PR DESCRIPTION
- The `codecov/codecov-action` GHA action does not support a `working-directory` option, it's called `directory` instead.
- Pyre does not work when the project isn't installed in editable mode (https://github.com/ansible-community/antsibull-docs/pull/137).