### PR TITLE
Deprecate support for classic changelogs (Ansible 2.9 and before)

### DIFF
--- a/changelogs/fragments/123-deprecate-classic.yml
+++ b/changelogs/fragments/123-deprecate-classic.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - "Support for ``classic`` changelogs is deprecated and will be removed soon. If you need to build changelogs for Ansible 2.9 or before, please use an older version (https://github.com/ansible-community/antsibull-changelog/pull/123)."

--- a/docs/changelog-configuration.rst
+++ b/docs/changelog-configuration.rst
@@ -60,6 +60,8 @@ The default value is ``classic`` for existing configurations, and ``combined`` f
 
 Determines whether ``changes_file`` contains only references to changelog fragments or plugins (was used internally by Ansible until version 2.9), or whether all fragments and plugin data is stored inside the file (used by Ansible 2.10 and in collections). Should never be set to ``classic``, except when using the changelog generator for Ansible 2.9 or earlier.
 
+Note that support for ``classic`` is **DEPRECATED** and will be removed in a future release. The field will from then on be required.
+
 ``flatmap`` (optional boolean)
 ------------------------------
 

--- a/src/antsibull_changelog/cli.py
+++ b/src/antsibull_changelog/cli.py
@@ -16,6 +16,7 @@ import json
 import os
 import sys
 import traceback
+import warnings
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -576,6 +577,15 @@ def _get_version_and_codename(
     return version, codename
 
 
+def _check_deprecation(config: ChangelogConfig):
+    if config.changes_format == "classic":
+        warnings.warn(
+            "Support for 'classic' changelogs (Ansible 2.9 and before) is deprecated"
+            " and will soon be removed from antsibull-changelog.",
+            DeprecationWarning,
+        )
+
+
 def command_release(args: Any) -> int:
     """
     Add a new release to a changelog.
@@ -589,6 +599,8 @@ def command_release(args: Any) -> int:
 
     collection_details = CollectionDetails(paths)
     config = ChangelogConfig.load(paths, collection_details)
+
+    _check_deprecation(config)
 
     load_collection_details(collection_details, args)
 
@@ -659,6 +671,8 @@ def command_generate(args: Any) -> int:
     collection_details = CollectionDetails(paths)
     config = ChangelogConfig.load(paths, collection_details)
 
+    _check_deprecation(config)
+
     load_collection_details(collection_details, args)
 
     flatmap = _determine_flatmap(collection_details, config)
@@ -698,6 +712,8 @@ def command_lint(args: Any) -> int:
     config = ChangelogConfig.load(
         paths, collection_details, ignore_is_other_project=True
     )
+
+    _check_deprecation(config)
 
     exceptions: list[tuple[str, Exception]] = []
     fragments = load_fragments(paths, config, fragment_paths, exceptions)


### PR DESCRIPTION
I think it's about time. This will allow to simplify some code.