### PR TITLE
Use 'hatch version' instead of manually updating the version

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -244,7 +244,13 @@ def bump(session: nox.Session):
         )
         with open(fragment_file, "w") as fp:
             print(fragment, file=fp)
-        session.run("git", "add", "pyproject.toml", fragment_file, external=True)
+        session.run(
+            "git",
+            "add",
+            "src/antsibull_changelog/__init__.py",
+            fragment_file,
+            external=True,
+        )
         session.run("git", "commit", "-m", f"Prepare {version}.", external=True)
     session.run("antsibull-changelog", "release")
     session.run(
@@ -253,9 +259,9 @@ def bump(session: nox.Session):
         "CHANGELOG.rst",
         "changelogs/changelog.yaml",
         "changelogs/fragments/",
-        # pyproject.toml is not committed in the last step
+        # __init__.py is not committed in the last step
         # when the release_summary fragment is created manually
-        "pyproject.toml",
+        "src/antsibull_changelog/__init__.py",
         external=True,
     )
     install(session, ".")  # Smoke test
@@ -281,5 +287,5 @@ def publish(session: nox.Session):
     install(session, "hatch")
     session.run("hatch", "publish", *session.posargs)
     session.run("hatch", "version", "post")
-    session.run("git", "add", "pyproject.toml", external=True)
+    session.run("git", "add", "src/antsibull_changelog/__init__.py", external=True)
     session.run("git", "commit", "-m", "Post-release version bump.", external=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -180,17 +180,6 @@ def typing(session: nox.Session):
     )
 
 
-def _repl_version(session: nox.Session, new_version: str):
-    with open("pyproject.toml", "r+") as fp:
-        lines = tuple(fp)
-        fp.seek(0)
-        for line in lines:
-            if line.startswith("version = "):
-                line = f'version = "{new_version}"\n'
-            fp.write(line)
-        fp.truncate()
-
-
 def check_no_modifications(session: nox.Session) -> None:
     modified = session.run(
         "git",
@@ -243,7 +232,9 @@ def bump(session: nox.Session):
                 f"Either {fragment_file} must already exist, or two positional arguments must be provided."
             )
     install(session, ".[toml]", "hatch")
-    _repl_version(session, version)
+    current_version = session.run("hatch", "version", silent=True).strip()
+    if version != current_version:
+        session.run("hatch", "version", version)
     if len(session.posargs) > 1:
         fragment = session.run(
             "python",
@@ -289,7 +280,6 @@ def publish(session: nox.Session):
     check_no_modifications(session)
     install(session, "hatch")
     session.run("hatch", "publish", *session.posargs)
-    version = session.run("hatch", "version", silent=True).strip()
-    _repl_version(session, f"{version}.post0")
+    session.run("hatch", "version", "post")
     session.run("git", "add", "pyproject.toml", external=True)
     session.run("git", "commit", "-m", "Post-release version bump.", external=True)

--- a/noxfile.py
+++ b/noxfile.py
@@ -252,7 +252,7 @@ def bump(session: nox.Session):
             external=True,
         )
         session.run("git", "commit", "-m", f"Prepare {version}.", external=True)
-    session.run("antsibull-changelog", "release")
+    session.run("antsibull-changelog", "release", "--version", version)
     session.run(
         "git",
         "add",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "antsibull-changelog"
-version = "0.23.0.post0"
+dynamic = ["version"]
 description = "Changelog tool for Ansible-base and Ansible collections"
 readme = "README.md"
 requires-python = ">= 3.9.0"
@@ -102,6 +102,9 @@ dev = [
     # misc
     "nox",
 ]
+
+[tool.hatch.version]
+path = "src/antsibull_changelog/__init__.py"
 
 [tool.isort]
 profile = "black"

--- a/src/antsibull_changelog/__init__.py
+++ b/src/antsibull_changelog/__init__.py
@@ -3,3 +3,11 @@
 # https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: 2020, Ansible Project
+
+"""
+Ansible Changelog Tool.
+"""
+
+__version__ = "0.23.0.post0"
+
+__all__ = ("__version__",)


### PR DESCRIPTION
We did this change to antsibull-docs some time ago. I had to fix that a bit today with https://github.com/ansible-community/antsibull-docs/commit/676780b99912f5e9d8b206b14a65ed03d8405919. This PR applies the noxfile changes to this project as well.