### PR TITLE
Add changelog entry for Python 3.12 support

### DIFF
--- a/changelogs/fragments/103-312.yaml
+++ b/changelogs/fragments/103-312.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Officially support Python 3.12
+    (https://github.com/ansible-community/antsibull-changelog/pull/134).


### PR DESCRIPTION
I figured this change could use a changelog fragment.

Relates: https://github.com/ansible-community/antsibull-changelog/pull/134
