### PR TITLE
Support rendering changelog as MarkDown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,433 @@
+# Ansible Changelog Tool Release Notes
+
+**Topics**
+- <a href="#v0-23-0">v0\.23\.0</a>
+  - <a href="#release-summary">Release Summary</a>
+  - <a href="#minor-changes">Minor Changes</a>
+- <a href="#v0-22-0">v0\.22\.0</a>
+  - <a href="#release-summary-1">Release Summary</a>
+  - <a href="#minor-changes-1">Minor Changes</a>
+- <a href="#v0-21-0">v0\.21\.0</a>
+  - <a href="#release-summary-2">Release Summary</a>
+  - <a href="#deprecated-features">Deprecated Features</a>
+- <a href="#v0-20-0">v0\.20\.0</a>
+  - <a href="#release-summary-3">Release Summary</a>
+  - <a href="#major-changes">Major Changes</a>
+  - <a href="#bugfixes">Bugfixes</a>
+- <a href="#v0-19-0">v0\.19\.0</a>
+  - <a href="#release-summary-4">Release Summary</a>
+  - <a href="#minor-changes-2">Minor Changes</a>
+- <a href="#v0-18-0">v0\.18\.0</a>
+  - <a href="#release-summary-5">Release Summary</a>
+  - <a href="#breaking-changes--porting-guide">Breaking Changes / Porting Guide</a>
+- <a href="#v0-17-0">v0\.17\.0</a>
+  - <a href="#release-summary-6">Release Summary</a>
+  - <a href="#minor-changes-3">Minor Changes</a>
+- <a href="#v0-16-0">v0\.16\.0</a>
+  - <a href="#release-summary-7">Release Summary</a>
+  - <a href="#minor-changes-4">Minor Changes</a>
+  - <a href="#bugfixes-1">Bugfixes</a>
+- <a href="#v0-15-0">v0\.15\.0</a>
+  - <a href="#release-summary-8">Release Summary</a>
+  - <a href="#minor-changes-5">Minor Changes</a>
+- <a href="#v0-14-0">v0\.14\.0</a>
+  - <a href="#release-summary-9">Release Summary</a>
+  - <a href="#minor-changes-6">Minor Changes</a>
+- <a href="#v0-13-0">v0\.13\.0</a>
+  - <a href="#release-summary-10">Release Summary</a>
+  - <a href="#minor-changes-7">Minor Changes</a>
+  - <a href="#bugfixes-2">Bugfixes</a>
+- <a href="#v0-12-0">v0\.12\.0</a>
+  - <a href="#release-summary-11">Release Summary</a>
+  - <a href="#minor-changes-8">Minor Changes</a>
+  - <a href="#bugfixes-3">Bugfixes</a>
+- <a href="#v0-11-0">v0\.11\.0</a>
+  - <a href="#minor-changes-9">Minor Changes</a>
+  - <a href="#bugfixes-4">Bugfixes</a>
+- <a href="#v0-10-0">v0\.10\.0</a>
+  - <a href="#minor-changes-10">Minor Changes</a>
+  - <a href="#bugfixes-5">Bugfixes</a>
+- <a href="#v0-9-0">v0\.9\.0</a>
+  - <a href="#major-changes-1">Major Changes</a>
+  - <a href="#minor-changes-11">Minor Changes</a>
+  - <a href="#breaking-changes--porting-guide-1">Breaking Changes / Porting Guide</a>
+- <a href="#v0-8-1">v0\.8\.1</a>
+  - <a href="#bugfixes-6">Bugfixes</a>
+- <a href="#v0-8-0">v0\.8\.0</a>
+  - <a href="#minor-changes-12">Minor Changes</a>
+- <a href="#v0-7-0">v0\.7\.0</a>
+  - <a href="#minor-changes-13">Minor Changes</a>
+- <a href="#v0-6-0">v0\.6\.0</a>
+  - <a href="#minor-changes-14">Minor Changes</a>
+- <a href="#v0-5-0">v0\.5\.0</a>
+  - <a href="#minor-changes-15">Minor Changes</a>
+- <a href="#v0-4-0">v0\.4\.0</a>
+  - <a href="#minor-changes-16">Minor Changes</a>
+  - <a href="#bugfixes-7">Bugfixes</a>
+- <a href="#v0-3-1">v0\.3\.1</a>
+  - <a href="#bugfixes-8">Bugfixes</a>
+- <a href="#v0-3-0">v0\.3\.0</a>
+  - <a href="#minor-changes-17">Minor Changes</a>
+- <a href="#v0-2-1">v0\.2\.1</a>
+  - <a href="#bugfixes-9">Bugfixes</a>
+- <a href="#v0-2-0">v0\.2\.0</a>
+  - <a href="#minor-changes-18">Minor Changes</a>
+- <a href="#v0-1-0">v0\.1\.0</a>
+  - <a href="#release-summary-12">Release Summary</a>
+
+<a id="v0-23-0"></a>
+## v0\.23\.0
+
+<a id="release-summary"></a>
+### Release Summary
+
+Feature release\.
+
+<a id="minor-changes"></a>
+### Minor Changes
+
+* Allow to generate changelog for a specific version \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/130](https\://github\.com/ansible\-community/antsibull\-changelog/pull/130)\)\.
+* Allow to generate only the last entry without preamble with the <code>generate</code> command \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/131](https\://github\.com/ansible\-community/antsibull\-changelog/pull/131)\)\.
+* Allow to write <code>generate</code> output to a user\-provided file \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/131](https\://github\.com/ansible\-community/antsibull\-changelog/pull/131)\)\.
+
+<a id="v0-22-0"></a>
+## v0\.22\.0
+
+<a id="release-summary-1"></a>
+### Release Summary
+
+New feature release
+
+<a id="minor-changes-1"></a>
+### Minor Changes
+
+* Add <code>antsibull\-changelog\-lint</code> and <code>antsibull\-changelog\-lint\-changelog\-yaml</code> pre\-commit\.com hooks \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/125](https\://github\.com/ansible\-community/antsibull\-changelog/pull/125)\)\.
+* Add <code>toml</code> extra to pull in a toml parser to use to guess the version based on <code>pyproject\.toml</code> \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/126](https\://github\.com/ansible\-community/antsibull\-changelog/pull/126)\)\.
+
+<a id="v0-21-0"></a>
+## v0\.21\.0
+
+<a id="release-summary-2"></a>
+### Release Summary
+
+Maintenance release with a deprecation\.
+
+<a id="deprecated-features"></a>
+### Deprecated Features
+
+* Support for <code>classic</code> changelogs is deprecated and will be removed soon\. If you need to build changelogs for Ansible 2\.9 or before\, please use an older version \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/123](https\://github\.com/ansible\-community/antsibull\-changelog/pull/123)\)\.
+
+<a id="v0-20-0"></a>
+## v0\.20\.0
+
+<a id="release-summary-3"></a>
+### Release Summary
+
+Bugfix and maintenance release using a new build system\.
+
+<a id="major-changes"></a>
+### Major Changes
+
+* Change pyproject build backend from <code>poetry\-core</code> to <code>hatchling</code>\. <code>pip install antsibull</code> works exactly the same as before\, but some users may be affected depending on how they build/install the project \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/109](https\://github\.com/ansible\-community/antsibull\-changelog/pull/109)\)\.
+
+<a id="bugfixes"></a>
+### Bugfixes
+
+* When releasing ansible\-core and only one of <code>\-\-version</code> and <code>\-\-codename</code> is supplied\, error out instead of ignoring the supplied value \([https\://github\.com/ansible\-community/antsibull\-changelog/issues/104](https\://github\.com/ansible\-community/antsibull\-changelog/issues/104)\, [https\://github\.com/ansible\-community/antsibull\-changelog/pull/105](https\://github\.com/ansible\-community/antsibull\-changelog/pull/105)\)\.
+
+<a id="v0-19-0"></a>
+## v0\.19\.0
+
+<a id="release-summary-4"></a>
+### Release Summary
+
+Feature release\.
+
+<a id="minor-changes-2"></a>
+### Minor Changes
+
+* Allow to extract other project versions for JavaScript / TypeScript projects from <code>package\.json</code> \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/100](https\://github\.com/ansible\-community/antsibull\-changelog/pull/100)\)\.
+* Allow to extract other project versions for Python projects from PEP 621 conformant <code>pyproject\.toml</code> \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/100](https\://github\.com/ansible\-community/antsibull\-changelog/pull/100)\)\.
+* Support Python 3\.11\'s <code>tomllib</code> to load <code>pyproject\.toml</code> \([https\://github\.com/ansible\-community/antsibull\-changelog/issues/101](https\://github\.com/ansible\-community/antsibull\-changelog/issues/101)\, [https\://github\.com/ansible\-community/antsibull\-changelog/pull/102](https\://github\.com/ansible\-community/antsibull\-changelog/pull/102)\)\.
+* Use more specific exceptions than <code>Exception</code> for some cases in internal code \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/103](https\://github\.com/ansible\-community/antsibull\-changelog/pull/103)\)\.
+
+<a id="v0-18-0"></a>
+## v0\.18\.0
+
+<a id="release-summary-5"></a>
+### Release Summary
+
+Maintenance release that drops support for older Python versions\.
+
+<a id="breaking-changes--porting-guide"></a>
+### Breaking Changes / Porting Guide
+
+* Drop support for Python 3\.6\, 3\.7\, and 3\.8 \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/93](https\://github\.com/ansible\-community/antsibull\-changelog/pull/93)\)\.
+
+<a id="v0-17-0"></a>
+## v0\.17\.0
+
+<a id="release-summary-6"></a>
+### Release Summary
+
+Feature release for ansible\-core\.
+
+<a id="minor-changes-3"></a>
+### Minor Changes
+
+* Only allow a <code>trival</code> section in the ansible\-core/ansible\-base changelog when explicitly configured \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/90](https\://github\.com/ansible\-community/antsibull\-changelog/pull/90)\)\.
+
+<a id="v0-16-0"></a>
+## v0\.16\.0
+
+<a id="release-summary-7"></a>
+### Release Summary
+
+Feature and bugfix release\.
+
+<a id="minor-changes-4"></a>
+### Minor Changes
+
+* Allow to extract other project versions for Python poetry projects from <code>pyproject\.toml</code> \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/80](https\://github\.com/ansible\-community/antsibull\-changelog/pull/80)\)\.
+* The files in the source repository now follow the [REUSE Specification](https\://reuse\.software/spec/)\. The only exceptions are changelog fragments in <code>changelogs/fragments/</code> \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/82](https\://github\.com/ansible\-community/antsibull\-changelog/pull/82)\)\.
+
+<a id="bugfixes-1"></a>
+### Bugfixes
+
+* Mark rstcheck 4\.x and 5\.x as compatible\. Support rstcheck 6\.x as well \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/81](https\://github\.com/ansible\-community/antsibull\-changelog/pull/81)\)\.
+
+<a id="v0-15-0"></a>
+## v0\.15\.0
+
+<a id="release-summary-8"></a>
+### Release Summary
+
+Feature release\.
+
+<a id="minor-changes-5"></a>
+### Minor Changes
+
+* Add <code>changelogs/changelog\.yaml</code> file format linting subcommand that was previously part of antsibull\-lint \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/76](https\://github\.com/ansible\-community/antsibull\-changelog/pull/76)\, [https\://github\.com/ansible\-community/antsibull/issues/410](https\://github\.com/ansible\-community/antsibull/issues/410)\)\.
+
+<a id="v0-14-0"></a>
+## v0\.14\.0
+
+<a id="release-summary-9"></a>
+### Release Summary
+
+Feature release that will speed up the release process with ansible\-core 2\.13\.
+
+<a id="minor-changes-6"></a>
+### Minor Changes
+
+* The internal <code>changelog\.yaml</code> linting API allows to use <code>packaging\.version\.Version</code> for version numbers instead of semantic versioning \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/73](https\://github\.com/ansible\-community/antsibull\-changelog/pull/73)\)\.
+* Use the new <code>\-\-metadata\-dump</code> option for ansible\-core 2\.13\+ to quickly dump and extract all module/plugin <code>version\_added</code> values for the collection \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/72](https\://github\.com/ansible\-community/antsibull\-changelog/pull/72)\)\.
+
+<a id="v0-13-0"></a>
+## v0\.13\.0
+
+<a id="release-summary-10"></a>
+### Release Summary
+
+This release makes changelog building more reliable\.
+
+<a id="minor-changes-7"></a>
+### Minor Changes
+
+* Always lint fragments before releasing \([https\://github\.com/ansible\-community/antsibull\-changelog/issues/65](https\://github\.com/ansible\-community/antsibull\-changelog/issues/65)\, [https\://github\.com/ansible\-community/antsibull\-changelog/pull/67](https\://github\.com/ansible\-community/antsibull\-changelog/pull/67)\)\.
+
+<a id="bugfixes-2"></a>
+### Bugfixes
+
+* Fix issues with module namespaces when symlinks appear in the path to the temp directory \([https\://github\.com/ansible\-community/antsibull\-changelog/issues/68](https\://github\.com/ansible\-community/antsibull\-changelog/issues/68)\, [https\://github\.com/ansible\-community/antsibull\-changelog/pull/69](https\://github\.com/ansible\-community/antsibull\-changelog/pull/69)\)\.
+* Stop mentioning <code>galaxy\.yaml</code> instead of <code>galaxy\.yml</code> in some error messages \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/66](https\://github\.com/ansible\-community/antsibull\-changelog/pull/66)\)\.
+
+<a id="v0-12-0"></a>
+## v0\.12\.0
+
+<a id="release-summary-11"></a>
+### Release Summary
+
+New feature release which supports other projects than ansible\-core and Ansible collections\.
+
+<a id="minor-changes-8"></a>
+### Minor Changes
+
+* Support changelogs for other projects than ansible\-core/\-base and Ansible collections \([https\://github\.com/ansible\-community/antsibull\-changelog/pull/60](https\://github\.com/ansible\-community/antsibull\-changelog/pull/60)\)\.
+
+<a id="bugfixes-3"></a>
+### Bugfixes
+
+* Fix prerelease collapsing when <code>use\_semantic\_versioning</code> is set to <code>true</code> for ansible\-core\.
+
+<a id="v0-11-0"></a>
+## v0\.11\.0
+
+<a id="minor-changes-9"></a>
+### Minor Changes
+
+* When using ansible\-core 2\.11 or newer\, will now detect new roles with argument spec\. We only consider the <code>main</code> entrypoint of roles\.
+
+<a id="bugfixes-4"></a>
+### Bugfixes
+
+* When subdirectories of <code>modules</code> are used in ansible\-base/ansible\-core\, the wrong module name was passed to <code>ansible\-doc</code> when <code>\-\-use\-ansible\-doc</code> was not used\.
+
+<a id="v0-10-0"></a>
+## v0\.10\.0
+
+<a id="minor-changes-10"></a>
+### Minor Changes
+
+* The new <code>\-\-cummulative\-release</code> option for <code>antsibull\-changelog release</code> allows to add all plugins and objects to a release since whose <code>version\_added</code> is later than the previous release version \(or ancestor if there was no previous release\)\, and at latest the current release version\. This is needed for major releases of <code>community\.general</code> and similarly organized collections\.
+* Will now print a warning when a release is made where the no <code>prelude\_section\_name</code> section \(default\: <code>release\_summary</code>\) appears\.
+
+<a id="bugfixes-5"></a>
+### Bugfixes
+
+* Make sure that the plugin caching inside ansible\-base/\-core works without <code>\-\-use\-ansible\-doc</code>\.
+
+<a id="v0-9-0"></a>
+## v0\.9\.0
+
+<a id="major-changes-1"></a>
+### Major Changes
+
+* Add support for reporting new playbooks and roles in collections\.
+* Add support for special changelog fragment sections which add new plugins and/or objects to the changelog for this version\. This is mainly useful for <code>test</code> and <code>filter</code> plugins\, and for <code>playbook</code> and <code>role</code> objects\, which are not yet automatically detected and mentioned in <code>changelogs/changelog\.yaml</code> or the generated RST changelog\.
+
+  The format of these sections and their content is as follows\:
+  ```
+  ---
+  add plugin.filter:
+    - name: to_time_unit
+      description: Converts a time expression to a given unit
+    - name: to_seconds
+      description: Converts a time expression to seconds
+  add object.role:
+    - name: nginx
+      description: The most awesome nginx installation role ever
+  add object.playbook:
+    - name: wipe_server
+      description: Totally wipes a server
+  ```
+
+  For every entry\, a list of plugins \(section <code>add plugin\.xxx</code>\) or objects \(section <code>add object\.xxx</code>\) of the given type \(<code>filter</code>\, <code>test</code> for plugins\, <code>playbook</code>\, <code>role</code> for objects\) will be added\. Every plugin or object has a short name as well as a short description\. These fields correspond to the module/plugin name and the <code>short\_description</code> field of the <code>DOCUMENTATION</code> block of modules and documentable plugins\.
+
+<a id="minor-changes-11"></a>
+### Minor Changes
+
+* Add <code>\-\-update\-existing</code> option for <code>antsibull\-changelog release</code>\, which allows to update the current release\'s release date and \(if relevant\) codename instead of simply reporting that the release already exists\.
+
+<a id="breaking-changes--porting-guide-1"></a>
+### Breaking Changes / Porting Guide
+
+* The new option <code>prevent\_known\_fragments</code> with default value being the value of <code>keep\_fragments</code> allows to control whether fragments with names that already appeared in the past are ignored or not\. The new behavior happens if <code>keep\_fragments\=false</code>\, and is less surprising to users \(see [https\://github\.com/ansible\-community/antsibull\-changelog/issues/46](https\://github\.com/ansible\-community/antsibull\-changelog/issues/46)\)\. Changelogs with <code>keep\_fragments\=true</code>\, like the ansible\-base/ansible\-core changelog\, are not affected\.
+
+<a id="v0-8-1"></a>
+## v0\.8\.1
+
+<a id="bugfixes-6"></a>
+### Bugfixes
+
+* Fixed error on generating changelogs when using the trivial section\.
+
+<a id="v0-8-0"></a>
+## v0\.8\.0
+
+<a id="minor-changes-12"></a>
+### Minor Changes
+
+* Allow to not save a changelog on release when using API\.
+* Allow to sanitize changelog data on load/save\. This means that unknown information will be removed\, and bad information will be stripped\. This will be enabled in newly created changelog configs\, but is disabled for backwards compatibility\.
+
+<a id="v0-7-0"></a>
+## v0\.7\.0
+
+<a id="minor-changes-13"></a>
+### Minor Changes
+
+* A new config option\, <code>ignore\_other\_fragment\_extensions</code> allows for configuring whether only <code>\.yaml</code> and <code>\.yml</code> files are used \(as mandated by the <code>ansible\-test sanity \-\-test changelog</code> test\)\. The default value for existing configurations is <code>false</code>\, and for new configurations <code>true</code>\.
+* Allow to use semantic versioning also for Ansible\-base with the <code>use\_semantic\_versioning</code> configuration setting\.
+* Refactoring changelog generation code to provide all preludes \(release summaries\) in changelog entries\, and provide generic functionality to extract a grouped list of versions\. These changes are mainly for the antsibull project\.
+
+<a id="v0-6-0"></a>
+## v0\.6\.0
+
+<a id="minor-changes-14"></a>
+### Minor Changes
+
+* New changelog configurations place the <code>CHANGELOG\.rst</code> file by default in the top\-level directory\, and not in <code>changelogs/</code>\.
+* The config option <code>archive\_path\_template</code> allows to move fragments into an archive directory when <code>keep\_fragments</code> is set to <code>false</code>\.
+* The option <code>use\_fqcn</code> \(set to <code>true</code> in new configurations\) allows to use FQCN for new plugins and modules\.
+
+<a id="v0-5-0"></a>
+## v0\.5\.0
+
+<a id="minor-changes-15"></a>
+### Minor Changes
+
+* The internal changelog generator code got more flexible to help antsibull generate Ansible porting guides\.
+
+<a id="v0-4-0"></a>
+## v0\.4\.0
+
+<a id="minor-changes-16"></a>
+### Minor Changes
+
+* Allow to enable or disable flatmapping via <code>config\.yaml</code>\.
+
+<a id="bugfixes-7"></a>
+### Bugfixes
+
+* Fix bad module namespace detection when collection was symlinked into Ansible\'s collection search path\. This also allows to add releases to collections which are not installed in a way that Ansible finds them\.
+
+<a id="v0-3-1"></a>
+## v0\.3\.1
+
+<a id="bugfixes-8"></a>
+### Bugfixes
+
+* Do not fail when <code>changelogs/fragments</code> does not exist\. Simply assume there are no fragments in that case\.
+* Improve behavior when <code>changelogs/config\.yaml</code> is not a dictionary\, or does not contain <code>sections</code>\.
+* Improve error message when <code>\-\-is\-collection</code> is specified and <code>changelogs/config\.yaml</code> cannot be found\, or when the <code>lint</code> subcommand is used\.
+
+<a id="v0-3-0"></a>
+## v0\.3\.0
+
+<a id="minor-changes-17"></a>
+### Minor Changes
+
+* Allow to pass path to ansible\-doc binary via <code>\-\-ansible\-doc\-bin</code>\.
+* Changelog generator can be ran via <code>python \-m antsibull\_changelog</code>\.
+* Use <code>ansible\-doc</code> instead of <code>/path/to/checkout/bin/ansible\-doc</code> when being run in ansible\-base checkouts\.
+
+<a id="v0-2-1"></a>
+## v0\.2\.1
+
+<a id="bugfixes-9"></a>
+### Bugfixes
+
+* Allow to enumerate plugins/modules with ansible\-doc by specifying <code>\-\-use\-ansible\-doc</code>\.
+
+<a id="v0-2-0"></a>
+## v0\.2\.0
+
+<a id="minor-changes-18"></a>
+### Minor Changes
+
+* Added more testing\.
+* Fix internal API for ACD changelog generation \(pruning and concatenation of changelogs\)\.
+* Improve error handling\.
+* Improve reStructuredText creation when new modules with and without namespace exist at the same time\.
+* Title generation improved \(remove superfluous space\)\.
+* Use PyYAML C loader/dumper if available\.
+* <code>lint</code> subcommand no longer requires specification whether it is run inside a collection or not \(if usual indicators are absent\)\.
+
+<a id="v0-1-0"></a>
+## v0\.1\.0
+
+<a id="release-summary-12"></a>
+### Release Summary
+
+Initial release as antsibull\-changelog\. The Ansible Changelog Tool has originally been developed by \@mattclay in [the ansible/ansible](https\://github\.com/ansible/ansible/blob/stable\-2\.9/packaging/release/changelogs/changelog\.py) repository for Ansible itself\. It has been extended in [felixfontein/ansible\-changelog](https\://github\.com/felixfontein/ansible\-changelog/) and [ansible\-community/antsibull](https\://github\.com/ansible\-community/antsibull/) to work with collections\, until it was moved to its current location [ansible\-community/antsibull\-changelog](https\://github\.com/ansible\-community/antsibull\-changelog/)\.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,6 +297,7 @@ New feature release which supports other projects than ansible\-core and Ansible
 * Add support for special changelog fragment sections which add new plugins and/or objects to the changelog for this version\. This is mainly useful for <code>test</code> and <code>filter</code> plugins\, and for <code>playbook</code> and <code>role</code> objects\, which are not yet automatically detected and mentioned in <code>changelogs/changelog\.yaml</code> or the generated RST changelog\.
 
   The format of these sections and their content is as follows\:
+
   ```
   ---
   add plugin.filter:

--- a/CHANGELOG.md.license
+++ b/CHANGELOG.md.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-FileCopyrightText: Ansible Project
+SPDX-License-Identifier: GPL-3.0-or-later

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,6 @@ Ansible Changelog Tool Release Notes
 
 .. contents:: Topics
 
-
 v0.23.0
 =======
 

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-changelog_filename_template: ../CHANGELOG.rst
+changelog_filename_template: ../CHANGELOG
 changelog_filename_version_depth: 0
 changes_file: changelog.yaml
 changes_format: combined
@@ -33,3 +33,6 @@ sections:
   - Known Issues
 use_semantic_versioning: true
 title: Ansible Changelog Tool
+output_formats:
+  - rst
+  - md

--- a/changelogs/fragments/139-output-formats.yml
+++ b/changelogs/fragments/139-output-formats.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Allow to render changelogs as MarkDown. The output formats written can be controlled with the ``output_formats`` option in the config file (https://github.com/ansible-community/antsibull-changelog/pull/139)."

--- a/changelogs/fragments/139-output-formats.yml
+++ b/changelogs/fragments/139-output-formats.yml
@@ -1,2 +1,6 @@
 minor_changes:
   - "Allow to render changelogs as MarkDown. The output formats written can be controlled with the ``output_formats`` option in the config file (https://github.com/ansible-community/antsibull-changelog/pull/139)."
+deprecated_features:
+  - "Some code in ``antsibull_changelog.changelog_entry`` has been deprecated, and the ``antsibull_changelog.rst`` module has been deprecated completely.
+     If you use them in your own code, please take a look at the `PR deprecating them <https://github.com/ansible-community/antsibull-changelog/pull/139>`__
+     for information on how to stop using them (https://github.com/ansible-community/antsibull-changelog/pull/139)."

--- a/docs/changelog-configuration.rst
+++ b/docs/changelog-configuration.rst
@@ -188,6 +188,14 @@ The default value is ``false`` for existing configurations, and ``true`` for new
 When set to ``true``, uses FQCN (Fully Qualified Collection Names) when mentioning new plugins and modules. This means that `namespace.name.` is prepended to the plugin resp. module names.
 
 
+``output_format`` (list of strings)
+-----------------------------------
+
+The default is ``["rst"]``.
+
+A list of output formats to write the changelog as. Supported formats are ``rst`` for ReStructuredText and ``md`` for MarkDown.
+
+
 Deprecated options
 ==================
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -144,7 +144,14 @@ def formatters(session: nox.Session):
 def codeqa(session: nox.Session):
     install(session, ".[codeqa]", editable=True)
     session.run("flake8", "src/antsibull_changelog", *session.posargs)
-    session.run("pylint", "--rcfile", ".pylintrc.automated", "src/antsibull_changelog")
+    session.run(
+        "pylint",
+        "--rcfile",
+        ".pylintrc.automated",
+        "src/antsibull_changelog",
+        "--ignore-imports",
+        "yes",
+    )
     session.run("reuse", "lint")
     session.run("antsibull-changelog", "lint")
 

--- a/src/antsibull_changelog/changelog_generator.py
+++ b/src/antsibull_changelog/changelog_generator.py
@@ -18,8 +18,8 @@ from collections.abc import MutableMapping
 from typing import Any, cast
 
 from .changes import ChangesBase, FragmentResolver, PluginResolver
-from .config import ChangelogConfig, PathsConfig
-from .fragment import ChangelogFragment, FragmentFormat
+from .config import ChangelogConfig, PathsConfig, TextFormat
+from .fragment import ChangelogFragment
 from .logger import LOGGER
 from .plugins import PluginDescription
 from .rst import RstBuilder
@@ -32,7 +32,7 @@ class ChangelogEntry:
     """
 
     version: str
-    text_format: FragmentFormat
+    text_format: TextFormat
 
     modules: list[Any]
     plugins: dict[Any, Any]
@@ -42,7 +42,7 @@ class ChangelogEntry:
 
     def __init__(self, version: str):
         self.version = version
-        self.text_format = FragmentFormat.RESTRUCTURED_TEXT
+        self.text_format = TextFormat.RESTRUCTURED_TEXT
         self.modules = []
         self.plugins = {}
         self.objects = {}

--- a/src/antsibull_changelog/changelog_generator.py
+++ b/src/antsibull_changelog/changelog_generator.py
@@ -276,6 +276,13 @@ def get_plugin_name(
 
 
 class ChangelogGenerator(ChangelogGeneratorBase):
+    # antsibull_changelog.rendering.changelog.ChangelogGenerator is a modified
+    # copy of this class adjust to the document rendering framework in
+    # antsibull_changelog.rendering. To avoid pylint complaining too much, we
+    # disable 'duplicate-code' for this class.
+
+    # pylint: disable=duplicate-code
+
     """
     Generate changelog as reStructuredText.
 

--- a/src/antsibull_changelog/changelog_generator.py
+++ b/src/antsibull_changelog/changelog_generator.py
@@ -75,6 +75,8 @@ class ChangelogEntry:
     def add_section_content(self, builder: RstBuilder, section_name: str) -> None:
         """
         Add a section's content of fragments to the changelog.
+
+        This function is DEPRECATED! It will be removed in a future version.
         """
         if section_name not in self.changes:
             return
@@ -289,6 +291,8 @@ class ChangelogGenerator(ChangelogGeneratorBase):
     This class can be both used to create a full changelog, or to append a
     changelog to an existing RstBuilder. This is for example useful to create
     a combined ACD changelog.
+
+    This class is DEPRECATED! It will be removed in a future version.
     """
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -578,6 +582,8 @@ def generate_changelog(  # pylint: disable=too-many-arguments
 ):
     """
     Generate the changelog as reStructuredText.
+
+    This function is DEPRECATED! It will be removed in a future version.
 
     :arg plugins: Will be loaded if necessary. Only provide when you already have them
     :arg fragments: Will be loaded if necessary. Only provide when you already have them

--- a/src/antsibull_changelog/cli.py
+++ b/src/antsibull_changelog/cli.py
@@ -28,14 +28,19 @@ except ImportError:
     HAS_ARGCOMPLETE = False
 
 from .ansible import get_ansible_release
-from .changelog_generator import generate_changelog
 from .changes import ChangesBase, add_release, load_changes
 from .config import ChangelogConfig, CollectionDetails, PathsConfig
 from .errors import ChangelogError
-from .fragment import ChangelogFragment, ChangelogFragmentLinter, load_fragments
+from .fragment import (
+    ChangelogFragment,
+    ChangelogFragmentLinter,
+    FragmentFormat,
+    load_fragments,
+)
 from .lint import lint_changelog_yaml
 from .logger import LOGGER, setup_logger
 from .plugins import PluginDescription, load_plugins
+from .rendering.changelog import generate_changelog
 from .toml import has_toml_loader_available, load_toml
 
 
@@ -670,7 +675,16 @@ def command_release(args: Any) -> int:
         prev_version=prev_version,
         objects=cast(list[PluginDescription], plugins),
     )
-    generate_changelog(paths, config, changes, plugins, fragments, flatmap=flatmap)
+    document_format = FragmentFormat.RESTRUCTURED_TEXT
+    generate_changelog(
+        paths,
+        config,
+        changes,
+        document_format,
+        plugins=plugins,
+        fragments=fragments,
+        flatmap=flatmap,
+    )
 
     return 0
 
@@ -716,12 +730,14 @@ def command_generate(args: Any) -> int:
             version=changes.latest_version,
             force_reload=args.reload_plugins,
         )
+    document_format = FragmentFormat.RESTRUCTURED_TEXT
     generate_changelog(
         paths,
         config,
         changes,
-        plugins,
-        fragments,
+        document_format,
+        plugins=plugins,
+        fragments=fragments,
         flatmap=flatmap,
         changelog_path=output,
         only_latest=only_latest,

--- a/src/antsibull_changelog/config.py
+++ b/src/antsibull_changelog/config.py
@@ -458,7 +458,12 @@ class ChangelogConfig:
 
         self.output_formats = set()
         for extension in self.config.get("output_formats", ["rst"]):
-            self.output_formats.add(TextFormat.from_extension(extension))
+            try:
+                self.output_formats.add(TextFormat.from_extension(extension))
+            except ValueError as exc:
+                raise ChangelogError(
+                    f"Found unknown extension in output_formats: {exc}"
+                ) from exc
 
         self._validate_config(ignore_is_other_project)
 

--- a/src/antsibull_changelog/config.py
+++ b/src/antsibull_changelog/config.py
@@ -12,12 +12,43 @@ Configuration classes for paths and changelogs.
 from __future__ import annotations
 
 import collections
+import enum
 import os
 from collections.abc import Mapping
 
 from .errors import ChangelogError
 from .logger import LOGGER
 from .yaml import load_yaml, store_yaml
+
+
+class TextFormat(enum.Enum):
+    """
+    Supported text formats.
+    """
+
+    RESTRUCTURED_TEXT = "restructuredtext"
+    MARKDOWN = "markdown"
+
+    def to_extension(self) -> str:
+        """
+        Convert a text format to the associated extension (without leading dot).
+        """
+        if self == TextFormat.RESTRUCTURED_TEXT:
+            return "rst"
+        if self == TextFormat.MARKDOWN:
+            return "md"
+        raise ValueError(f"Unknown text format {self}")
+
+    @staticmethod
+    def from_extension(extension: str) -> TextFormat:
+        """
+        Convert a file extension (without leading dot) to the corresponding text format.
+        """
+        if extension == "rst":
+            return TextFormat.RESTRUCTURED_TEXT
+        if extension == "md":
+            return TextFormat.MARKDOWN
+        raise ValueError(f"Unknown extension {extension!r}")
 
 
 def _is_other_project_config(config_path: str) -> bool:
@@ -346,6 +377,7 @@ class ChangelogConfig:
     use_semantic_versioning: bool
     is_other_project: bool
     sections: Mapping[str, str]
+    output_formats: set[TextFormat]
 
     def __init__(
         self,
@@ -423,6 +455,10 @@ class ChangelogConfig:
         ):
             sections[section_name] = section_title
         self.sections = sections
+
+        self.output_formats = set()
+        for extension in self.config.get("output_formats", ["rst"]):
+            self.output_formats.add(TextFormat.from_extension(extension))
 
         self._validate_config(ignore_is_other_project)
 
@@ -504,6 +540,10 @@ class ChangelogConfig:
                 continue
             sections.append([key, value])
         config["sections"] = sections
+
+        config["output_formats"] = sorted(
+            text_format.to_extension() for text_format in self.output_formats
+        )
 
         store_yaml(self.paths.config_path, config)
 

--- a/src/antsibull_changelog/fragment.py
+++ b/src/antsibull_changelog/fragment.py
@@ -11,6 +11,7 @@ Changelog fragment loading, modification and linting.
 
 from __future__ import annotations
 
+import enum
 import os
 from typing import Any
 
@@ -22,6 +23,15 @@ from .rstcheck import check_rst_content
 from .yaml import load_yaml
 
 
+class FragmentFormat(enum.Enum):
+    """
+    Supported fragment formats.
+    """
+
+    RESTRUCTURED_TEXT = "restructuredtext"
+    MARKDOWN = "markdown"
+
+
 class ChangelogFragment:
     """
     A changelog fragment.
@@ -30,14 +40,21 @@ class ChangelogFragment:
     content: dict[str, list[str] | str]
     path: str
     name: str
+    fragment_format: FragmentFormat
 
-    def __init__(self, content: dict[str, list[str] | str], path: str):
+    def __init__(
+        self,
+        content: dict[str, list[str] | str],
+        path: str,
+        fragment_format: FragmentFormat = FragmentFormat.RESTRUCTURED_TEXT,
+    ):
         """
         Create changelog fragment.
         """
         self.content = content
         self.path = path
         self.name = os.path.basename(path)
+        self.fragment_format = fragment_format
 
     def remove(self) -> None:
         """
@@ -68,21 +85,25 @@ class ChangelogFragment:
             )
 
     @staticmethod
-    def load(path: str) -> "ChangelogFragment":
+    def load(
+        path: str, fragment_format: FragmentFormat = FragmentFormat.RESTRUCTURED_TEXT
+    ) -> "ChangelogFragment":
         """
         Load a ``ChangelogFragment`` from a file.
         """
         content = load_yaml(path)
-        return ChangelogFragment(content, path)
+        return ChangelogFragment(content, path, fragment_format=fragment_format)
 
     @staticmethod
     def from_dict(
-        data: dict[str, list[str] | str], path: str = ""
+        data: dict[str, list[str] | str],
+        path: str = "",
+        fragment_format: FragmentFormat = FragmentFormat.RESTRUCTURED_TEXT,
     ) -> "ChangelogFragment":
         """
         Create a ``ChangelogFragment`` from a dictionary.
         """
-        return ChangelogFragment(data, path)
+        return ChangelogFragment(data, path, fragment_format=fragment_format)
 
     @staticmethod
     def combine(
@@ -327,6 +348,15 @@ class ChangelogFragmentLinter:
                 errors.append((fragment.path, 0, 0, "invalid section: %s" % section))
 
     @staticmethod
+    def _check_content(
+        text: str, text_format: FragmentFormat, filename: str
+    ) -> list[str]:
+        if text_format == FragmentFormat.RESTRUCTURED_TEXT:
+            results = check_rst_content(text, filename=filename)
+            return [result[2] for result in results]
+        raise ValueError("No validation possible for MarkDown fragments")
+
+    @staticmethod
     def _lint_lines(
         errors: list[tuple[str, int, int, str]],
         fragment: ChangelogFragment,
@@ -352,10 +382,14 @@ class ChangelogFragmentLinter:
                     )
                     continue
 
-                results = check_rst_content(line, filename=fragment.path)
+                results = ChangelogFragmentLinter._check_content(
+                    line, fragment.fragment_format, fragment.path
+                )
                 errors += [(fragment.path, 0, 0, result[2]) for result in results]
         elif isinstance(lines, str):
-            results = check_rst_content(lines, filename=fragment.path)
+            results = ChangelogFragmentLinter._check_content(
+                lines, fragment.fragment_format, fragment.path
+            )
             errors += [(fragment.path, 0, 0, result[2]) for result in results]
 
     def lint(self, fragment: ChangelogFragment) -> list[tuple[str, int, int, str]]:

--- a/src/antsibull_changelog/fragment.py
+++ b/src/antsibull_changelog/fragment.py
@@ -11,25 +11,15 @@ Changelog fragment loading, modification and linting.
 
 from __future__ import annotations
 
-import enum
 import os
 from typing import Any
 
 from .ansible import OBJECT_TYPES, OTHER_PLUGIN_TYPES, get_documentable_plugins
-from .config import ChangelogConfig, PathsConfig
+from .config import ChangelogConfig, PathsConfig, TextFormat
 from .errors import ChangelogError
 from .logger import LOGGER
 from .rstcheck import check_rst_content
 from .yaml import load_yaml
-
-
-class FragmentFormat(enum.Enum):
-    """
-    Supported fragment formats.
-    """
-
-    RESTRUCTURED_TEXT = "restructuredtext"
-    MARKDOWN = "markdown"
 
 
 class ChangelogFragment:
@@ -40,13 +30,13 @@ class ChangelogFragment:
     content: dict[str, list[str] | str]
     path: str
     name: str
-    fragment_format: FragmentFormat
+    fragment_format: TextFormat
 
     def __init__(
         self,
         content: dict[str, list[str] | str],
         path: str,
-        fragment_format: FragmentFormat = FragmentFormat.RESTRUCTURED_TEXT,
+        fragment_format: TextFormat = TextFormat.RESTRUCTURED_TEXT,
     ):
         """
         Create changelog fragment.
@@ -86,7 +76,7 @@ class ChangelogFragment:
 
     @staticmethod
     def load(
-        path: str, fragment_format: FragmentFormat = FragmentFormat.RESTRUCTURED_TEXT
+        path: str, fragment_format: TextFormat = TextFormat.RESTRUCTURED_TEXT
     ) -> "ChangelogFragment":
         """
         Load a ``ChangelogFragment`` from a file.
@@ -98,7 +88,7 @@ class ChangelogFragment:
     def from_dict(
         data: dict[str, list[str] | str],
         path: str = "",
-        fragment_format: FragmentFormat = FragmentFormat.RESTRUCTURED_TEXT,
+        fragment_format: TextFormat = TextFormat.RESTRUCTURED_TEXT,
     ) -> "ChangelogFragment":
         """
         Create a ``ChangelogFragment`` from a dictionary.
@@ -348,10 +338,8 @@ class ChangelogFragmentLinter:
                 errors.append((fragment.path, 0, 0, "invalid section: %s" % section))
 
     @staticmethod
-    def _check_content(
-        text: str, text_format: FragmentFormat, filename: str
-    ) -> list[str]:
-        if text_format == FragmentFormat.RESTRUCTURED_TEXT:
+    def _check_content(text: str, text_format: TextFormat, filename: str) -> list[str]:
+        if text_format == TextFormat.RESTRUCTURED_TEXT:
             results = check_rst_content(text, filename=filename)
             return [result[2] for result in results]
         raise ValueError("No validation possible for MarkDown fragments")

--- a/src/antsibull_changelog/rendering/__init__.py
+++ b/src/antsibull_changelog/rendering/__init__.py
@@ -1,0 +1,5 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2023, Ansible Project

--- a/src/antsibull_changelog/rendering/_document.py
+++ b/src/antsibull_changelog/rendering/_document.py
@@ -149,6 +149,35 @@ class AbstractRendererEx(BaseContent, AbstractRenderer):
         )
 
 
+def _render(abstract_renderer: AbstractRendererEx, start_level: int = 0) -> str:
+    # Make sure everything is generated
+    abstract_renderer.generate()
+    for content in abstract_renderer.content:
+        content.generate()
+
+    # Generate lines
+    lines: list[str] = []
+    abstract_renderer.append_lines(lines, start_level=start_level)
+
+    # Return lines
+    return "\n".join(lines) + "\n"  # add trailing newline
+
+
+def render_section(
+    abstract_renderer: AbstractRendererEx,
+) -> str:
+    """
+    Renders the section to a string.
+
+    :arg abstract_renderer: View of the section as an extended abstract renderer.
+    """
+    # Check
+    if not abstract_renderer.closed:
+        raise ValueError(f"Section {abstract_renderer} is not closed")
+
+    return _render(abstract_renderer)
+
+
 def render_document(
     document_renderer: DocumentRendererEx,
     abstract_renderer: AbstractRendererEx,
@@ -164,20 +193,17 @@ def render_document(
     if document_renderer.start_level == 0 and document_renderer.title is None:
         raise ValueError("Title must be specified if start_level == 0")
 
-    # Make sure everything is generated
-    abstract_renderer.generate()
-    for content in abstract_renderer.content:
-        content.generate()
-
-    # Generate lines
-    lines: list[str] = []
-    abstract_renderer.append_lines(
-        lines,
-        start_level=abstract_renderer._get_level(),  # pylint: disable=protected-access
+    return _render(
+        abstract_renderer,
+        start_level=document_renderer.start_level,
     )
 
-    # Return lines
-    return "\n".join(lines) + "\n"  # add trailing newline
 
-
-__all__ = ("BaseContent", "DocumentRendererEx", "TextRenderer", "AbstractRendererEx")
+__all__ = (
+    "BaseContent",
+    "DocumentRendererEx",
+    "TextRenderer",
+    "AbstractRendererEx",
+    "render_section",
+    "render_document",
+)

--- a/src/antsibull_changelog/rendering/_document.py
+++ b/src/antsibull_changelog/rendering/_document.py
@@ -14,6 +14,7 @@ import abc
 
 from ..config import TextFormat
 from .document import AbstractRenderer, DocumentRenderer
+from .utils import ensure_newline_after_last_content
 
 
 class BaseContent(abc.ABC):
@@ -60,6 +61,20 @@ class DocumentRendererEx(DocumentRenderer):
         if self.title is not None:
             raise ValueError("Document title already set")
         self.title = title
+
+
+class ParagraphBreak(BaseContent):
+    """
+    Paragraph break.
+    """
+
+    def __init__(
+        self,
+    ):
+        super().__init__(already_closed=True)
+
+    def append_lines(self, lines: list[str], start_level: int = 0) -> None:
+        ensure_newline_after_last_content(lines)
 
 
 class TextRenderer(BaseContent):
@@ -125,8 +140,7 @@ class AbstractRendererEx(BaseContent, AbstractRenderer):
     def _get_level(self) -> int:
         pass
 
-    def _generate_all(self) -> None:
-        self.generate()
+    def generate(self) -> None:
         for content in self.content:
             content.generate()
 
@@ -147,6 +161,9 @@ class AbstractRendererEx(BaseContent, AbstractRenderer):
                 indent_next="  ",
             )
         )
+
+    def ensure_paragraph_break(self) -> None:
+        self.content.append(ParagraphBreak())
 
 
 def _render(abstract_renderer: AbstractRendererEx, start_level: int = 0) -> str:

--- a/src/antsibull_changelog/rendering/_document.py
+++ b/src/antsibull_changelog/rendering/_document.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import abc
 
-from ..fragment import FragmentFormat
+from ..config import TextFormat
 from .document import AbstractRenderer, DocumentRenderer
 
 
@@ -51,7 +51,7 @@ class DocumentRendererEx(DocumentRenderer):
         self.title = None
 
     @abc.abstractmethod
-    def render_text(self, text: str, text_format: FragmentFormat) -> str:
+    def render_text(self, text: str, text_format: TextFormat) -> str:
         """
         Render a text as ReStructured Text.
         """
@@ -68,7 +68,7 @@ class TextRenderer(BaseContent):
     """
 
     text: str
-    text_format: FragmentFormat
+    text_format: TextFormat
     root: DocumentRendererEx
     indent_first: str
     indent_next: str
@@ -77,7 +77,7 @@ class TextRenderer(BaseContent):
     def __init__(
         self,
         text: str,
-        text_format: FragmentFormat,
+        text_format: TextFormat,
         /,
         root: DocumentRendererEx,
         indent_first: str = "",
@@ -130,12 +130,12 @@ class AbstractRendererEx(BaseContent, AbstractRenderer):
         for content in self.content:
             content.generate()
 
-    def add_text(self, text: str, text_format: FragmentFormat) -> None:
+    def add_text(self, text: str, text_format: TextFormat) -> None:
         if self.closed:
             raise ValueError("{self} is already closed")
         self.content.append(TextRenderer(text, text_format, root=self.root))
 
-    def add_fragment(self, text: str, text_format: FragmentFormat) -> None:
+    def add_fragment(self, text: str, text_format: TextFormat) -> None:
         if self.closed:
             raise ValueError("{self} is already closed")
         self.content.append(

--- a/src/antsibull_changelog/rendering/changelog.py
+++ b/src/antsibull_changelog/rendering/changelog.py
@@ -426,7 +426,7 @@ def generate_changelog(  # pylint: disable=too-many-arguments
         changelog_fd.write(text)
 
 
-__ALL__ = (
+__all__ = (
     "add_section_content",
     "ChangelogGenerator",
     "create_document_renderer",

--- a/src/antsibull_changelog/rendering/changelog.py
+++ b/src/antsibull_changelog/rendering/changelog.py
@@ -430,6 +430,5 @@ __ALL__ = (
     "add_section_content",
     "ChangelogGenerator",
     "create_document_renderer",
-    "get_format_extension",
     "generate_changelog",
 )

--- a/src/antsibull_changelog/rendering/document.py
+++ b/src/antsibull_changelog/rendering/document.py
@@ -1,0 +1,90 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2024, Ansible Project
+
+"""
+Abstract functionality for rendering a document.
+"""
+
+from __future__ import annotations
+
+import abc
+
+from ..fragment import FragmentFormat
+
+
+class AbstractRenderer(abc.ABC):
+    """
+    Abstract renderer. Can be a document or section, for example.
+    """
+
+    @abc.abstractmethod
+    def add_section(self, title: str) -> "SectionRenderer":
+        """
+        Add a (sub-)section.
+        """
+
+    @abc.abstractmethod
+    def add_toc(self, title: str | None = None, max_depth: int | None = None) -> None:
+        """
+        Add a table of contents starting at this section.
+        """
+
+    @abc.abstractmethod
+    def add_text(self, text: str, text_format: FragmentFormat) -> None:
+        """
+        Add a text.
+        """
+
+    @abc.abstractmethod
+    def add_fragment(self, text: str, text_format: FragmentFormat) -> None:
+        """
+        Add a fragment (as a list item).
+        """
+
+
+class SectionRenderer(AbstractRenderer):
+    """
+    Renders a section.
+    """
+
+    def close(self) -> None:
+        """
+        Closes the section.
+
+        All subsections must be closed before calling this.
+        After calling this, no other method but ``render()`` can be called.
+        """
+
+    @abc.abstractmethod
+    def render(self) -> str:
+        """
+        Render the document to a string.
+
+        Must be closed before calling this.
+        """
+
+
+class DocumentRenderer(AbstractRenderer):
+    """
+    Renders a document.
+    """
+
+    @abc.abstractmethod
+    def set_title(self, title: str) -> None:
+        """
+        Set the top-level title of the document
+        """
+
+    @abc.abstractmethod
+    def render(self) -> str:
+        """
+        Render the document to a string.
+
+        All sections must be closed before calling this.
+        """
+
+
+__all__ = ("AbstractRenderer", "SectionRenderer", "DocumentRenderer")

--- a/src/antsibull_changelog/rendering/document.py
+++ b/src/antsibull_changelog/rendering/document.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import abc
 
-from ..fragment import FragmentFormat
+from ..config import TextFormat
 
 
 class AbstractRenderer(abc.ABC):
@@ -33,13 +33,13 @@ class AbstractRenderer(abc.ABC):
         """
 
     @abc.abstractmethod
-    def add_text(self, text: str, text_format: FragmentFormat) -> None:
+    def add_text(self, text: str, text_format: TextFormat) -> None:
         """
         Add a text.
         """
 
     @abc.abstractmethod
-    def add_fragment(self, text: str, text_format: FragmentFormat) -> None:
+    def add_fragment(self, text: str, text_format: TextFormat) -> None:
         """
         Add a fragment (as a list item).
         """
@@ -84,6 +84,14 @@ class DocumentRenderer(AbstractRenderer):
         Render the document to a string.
 
         All sections must be closed before calling this.
+        """
+
+    @abc.abstractmethod
+    def get_warnings(self) -> list[str]:
+        """
+        Retrieve a list of warnings encountered while rendering.
+
+        Must only be called after calling ``render()``.
         """
 
 

--- a/src/antsibull_changelog/rendering/document.py
+++ b/src/antsibull_changelog/rendering/document.py
@@ -44,6 +44,12 @@ class AbstractRenderer(abc.ABC):
         Add a fragment (as a list item).
         """
 
+    @abc.abstractmethod
+    def ensure_paragraph_break(self) -> None:
+        """
+        Ensure that a paragraph break happens.
+        """
+
 
 class SectionRenderer(AbstractRenderer):
     """

--- a/src/antsibull_changelog/rendering/markdown.py
+++ b/src/antsibull_changelog/rendering/markdown.py
@@ -340,7 +340,7 @@ class Translator(nodes.NodeVisitor):  # pylint: disable=too-many-public-methods
         """
         context = self._context.top
         context.close()
-        return context.get_text()
+        return context.get_text().lstrip("\n").rstrip("\n")
 
     def _add_label(self, label: str) -> None:
         if label in self._context.created_labels:

--- a/src/antsibull_changelog/rendering/markdown.py
+++ b/src/antsibull_changelog/rendering/markdown.py
@@ -20,6 +20,8 @@ from urllib.parse import quote as _urllib_quote
 
 from docutils import nodes, writers
 from docutils.core import publish_parts
+from docutils.writers.html5_polyglot import HTMLTranslator
+from docutils.writers.html5_polyglot import Writer as HTMLWriter
 
 from .utils import RenderResult, SupportedParser, get_docutils_publish_settings
 
@@ -679,11 +681,23 @@ class Translator(nodes.NodeVisitor):  # pylint: disable=too-many-public-methods
         if "refid" in node.attributes:
             self._context.top.add_main("</a>")
 
+    # Node: problematic
+
+    # pylint: disable-next=missing-function-docstring
+    def visit_table(self, node):
+        translator = HTMLTranslator(self.document)
+        node.walkabout(translator)
+        self._context.top.add_main("".join(translator.body).strip())
+        raise nodes.SkipNode
+
 
 class MarkDownWriter(writers.Writer):
     """
     Create a MarkDown document from a docutils node tree.
     """
+
+    # Needed to be able to run HTMLTranslator on nodes
+    settings_spec = HTMLWriter.settings_spec
 
     def __init__(self, document_context: DocumentContext):
         writers.Writer.__init__(self)

--- a/src/antsibull_changelog/rendering/markdown.py
+++ b/src/antsibull_changelog/rendering/markdown.py
@@ -1,0 +1,679 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022, Ansible Project
+
+"""
+Code for conversion to MarkDown.
+"""
+
+# pyre-ignore-all-errors
+
+from __future__ import annotations
+
+import re
+import typing as t
+from html import escape as _html_escape_basic
+from urllib.parse import quote as _urllib_quote
+
+from docutils import nodes, writers
+from docutils.core import publish_parts
+
+from .utils import _DOCUTILS_PUBLISH_SETTINGS, RenderResult, SupportedParser
+
+_MD_ESCAPE = re.compile(r"""([!"#$%&'()*+,:;<=>?@[\\\]^_`{|}~.-])""")
+
+
+def _md_escape(text: str) -> str:
+    return _MD_ESCAPE.sub(r"\\\1", text)
+
+
+def _html_escape(text: str) -> str:
+    return _html_escape_basic(text).replace("&quot;", '"')
+
+
+class GlobalContext:  # pylint: disable=too-few-public-methods
+    """
+    The global conversion context.
+    """
+
+    # How labels are mapped to link fragments
+    labels: dict[str, str]
+
+    def __init__(self):
+        self.labels = {}
+
+    def register_label(self, label: str) -> str:
+        """
+        Register a label. Produces the corresponding link fragment.
+        """
+        if label in self.labels:
+            return self.labels[label]
+        fragment = _urllib_quote(label, safe="")
+        self.labels[label] = fragment
+        return fragment
+
+
+class Context:
+    """
+    Base context class for MarkDown conversion.
+    """
+
+    escape: bool
+
+    _has_top: bool
+
+    _top: list[str]
+    _main: list[str]
+
+    def __init__(self, has_top=False, escape=True):
+        self.escape = escape
+        self._has_top = has_top
+        self._top = []
+        self._main = []
+
+    def add_top(self, text: str) -> None:
+        """
+        Add text to the top part.
+        """
+        if not self._has_top:
+            raise ValueError("Context has no top part")
+        self._top.append(text)
+
+    def add_main(self, text: str) -> None:
+        """
+        Add text to the main part.
+        """
+        self._main.append(text)
+
+    def replace_main(self, lines: list[str] | None = None) -> None:
+        """
+        Replace the content of the main part by the new list of strings.
+        """
+        self._main.clear()
+        if lines:
+            self._main.extend(lines)
+
+    def ensure_newline(self) -> None:
+        """
+        Ensure that the main part ends with a newline, if it is not empty.
+        """
+        if self._main and not self._main[-1].endswith("\n"):
+            self._main.append("\n")
+
+    def append(
+        self,
+        context: "Context",
+    ) -> None:
+        """
+        Append another context to this context.
+        """
+        if context._has_top:  # pylint: disable=protected-access
+            if not self._has_top:
+                raise ValueError("Context has no top part")
+            self._top.extend(context._top)  # pylint: disable=protected-access
+        self._main.extend(context._main)  # pylint: disable=protected-access
+
+    def close(self) -> None:
+        """
+        Close the context.
+
+        Should be called before using its value / content, for example by
+        passing it to ``append()`` or calling ``get_text()``.
+        """
+
+    def get_text(self) -> str:
+        """
+        Return the content of the context as a string.
+        """
+        return "".join(self._top + self._main)
+
+
+class ListContext(Context):
+    """
+    Context for lists (enumeration, bullet list).
+    """
+
+    first_indent: str
+    next_indent: str
+
+    def __init__(self, indent: str):
+        super().__init__()
+        self.first_indent = indent
+        self.next_indent = " " * len(indent)
+
+
+def get_language_from_literal_block(node: nodes.literal_block) -> str | None:
+    """
+    Obtain programming language from a literal block.
+    """
+    # Some versions store the language in the "language" attribute
+    if "language" in node.attributes:
+        return node.attributes["language"]
+    # Some others simply store it as a class name that's not "code" or "code-block"
+    for class_name in node.attributes["classes"]:
+        if class_name not in ("code", "code-block"):
+            return class_name
+    return None
+
+
+def count_leading_backticks(line: str) -> int:
+    """
+    Count the number of leading backticks of a string.
+    """
+    count = 0
+    length = len(line)
+    while count < length and line[count] == "`":
+        count += 1
+    return count
+
+
+class DocumentContext:
+    """
+    Conversion context for a document.
+    """
+
+    section_depth: int
+    global_context: GlobalContext
+    unknown_node_types: set[str]
+    created_labels: set[str]
+
+    _contexts: list[Context]
+
+    def __init__(self, global_context: GlobalContext):
+        self.section_depth = 0
+        self.global_context = global_context
+        self.unknown_node_types = set()
+        self.created_labels = set()
+        self._contexts = [Context(has_top=True)]
+
+    def push_context(self, context: Context) -> None:
+        """
+        Add a new context on the context stack.
+        """
+        self._contexts.append(context)
+
+    def pop_context(self) -> None:
+        """
+        Pop the top-most context from the context stack.
+
+        The last context cannot be popped, trying to do so will result in a
+        ``ValueError`` exception.
+        """
+        if len(self._contexts) < 2:
+            raise ValueError("Cannot pop last element")
+        context = self._contexts.pop()
+        context.close()
+        self._contexts[-1].append(context)
+
+    @property
+    def top(self) -> Context:
+        """
+        Return the top-most context from the context stack.
+        """
+        return self._contexts[-1]
+
+
+_Class = t.TypeVar("_Class")
+
+
+def _add_unsupported_classes(clazz: _Class) -> _Class:
+    def get_visit(class_name: str):
+        # pylint: disable-next=unused-argument
+        def visit_unsupported(self: t.Any, node: nodes.Node):
+            # pylint: disable-next=protected-access
+            self._context.unknown_node_types.add(class_name)
+            raise nodes.SkipNode
+
+        return visit_unsupported
+
+    for class_name in nodes.node_class_names:
+        function_name = f"visit_{class_name}"
+        if not hasattr(clazz, function_name):
+            setattr(clazz, function_name, get_visit(class_name))
+
+    return clazz
+
+
+def _add_simple(
+    definitions: dict[str, tuple[str, str]]
+) -> t.Callable[[_Class], _Class]:
+    def decorator(clazz: _Class) -> _Class:
+        def get_visit(start: str):
+            # pylint: disable-next=unused-argument
+            def visit(self: t.Any, node: nodes.Node) -> None:
+                if start:
+                    # pylint: disable-next=protected-access
+                    self._context.top.add_main(start)
+
+            return visit
+
+        def get_depart(end: str):
+            # pylint: disable-next=unused-argument
+            def depart(self: t.Any, node: nodes.Node) -> None:
+                if end:
+                    # pylint: disable-next=protected-access
+                    self._context.top.add_main(end)
+
+            return depart
+
+        for class_name, (start, end) in definitions.items():
+            setattr(clazz, f"visit_{class_name}", get_visit(start))
+            setattr(clazz, f"depart_{class_name}", get_depart(end))
+        return clazz
+
+    return decorator
+
+
+def _add_skip(class_names: list[str]) -> t.Callable[[_Class], _Class]:
+    def decorator(clazz: _Class) -> _Class:
+        def visit(self: t.Any, node: nodes.Node) -> None:
+            raise nodes.SkipNode
+
+        for class_name in class_names:
+            setattr(clazz, f"visit_{class_name}", visit)
+        return clazz
+
+    return decorator
+
+
+@_add_unsupported_classes
+@_add_simple(
+    {
+        "document": ("", ""),
+        "inline": ("", ""),
+        "generated": ("", ""),
+        "paragraph": ("\n", "\n"),
+        "literal": ("<code>", "</code>"),
+        "emphasis": ("<em>", "</em>"),
+        "strong": ("<strong>", "</strong>"),
+        "subscript": ("<sub>", "</sub>"),
+        "superscript": ("<sup>", "</sup>"),
+    }
+)
+@_add_skip(
+    [
+        "comment",
+    ]
+)
+class Translator(nodes.NodeVisitor):  # pylint: disable=too-many-public-methods
+    """
+    Translates a docutils node tree to MarkDown in a ``DocumentContext``.
+    """
+
+    _context: DocumentContext
+
+    def __init__(self, document, document_context: DocumentContext):
+        super().__init__(document)
+        self._context = document_context
+
+    def get_text(self) -> str:
+        """
+        Return the result as a text.
+
+        Must only be called after processing the document, and at most once.
+        """
+        context = self._context.top
+        context.close()
+        return context.get_text()
+
+    def _add_label(self, label: str) -> None:
+        if label in self._context.created_labels:
+            return
+        self._context.created_labels.add(label)
+        ref = self._context.global_context.register_label(label)
+        self._context.top.add_main(f'<a id="{ref}"></a>\n')
+
+    # Node: title
+
+    # pylint: disable-next=missing-function-docstring
+    def visit_title(self, node: nodes.title) -> None:
+        level = self._context.section_depth + 1
+        title = node.astext()
+        text = f'{"#" * level} {_md_escape(title)}\n\n'
+        if self._context.section_depth == 0:
+            self._context.top.add_top(text)
+        else:
+            self._context.top.ensure_newline()
+            self._context.top.add_main(text)
+        raise nodes.SkipNode
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def depart_title(self, node: nodes.title) -> None:
+        self._context.top.add_main("\n")
+
+    # Node: section
+
+    # pylint: disable-next=missing-function-docstring
+    def visit_section(self, node: nodes.section) -> None:
+        if "ids" in node.attributes:
+            for ref in node.attributes["ids"]:
+                self._add_label(ref)
+        self._context.section_depth += 1
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def depart_section(self, node: nodes.section) -> None:
+        self._context.section_depth -= 1
+
+    # Node: text
+
+    # pylint: disable-next=missing-function-docstring,invalid-name
+    def visit_Text(self, node: nodes.Text) -> None:
+        text = node.astext()
+        if self._context.top.escape:
+            text = _md_escape(text)
+        self._context.top.add_main(text)
+
+    # pylint: disable-next=missing-function-docstring,invalid-name
+    def depart_Text(self, node: nodes.Text) -> None:
+        pass
+
+    # Node: target
+
+    # pylint: disable-next=missing-function-docstring
+    def visit_target(self, node: nodes.target) -> None:
+        if "refid" in node.attributes:
+            self._add_label(node.attributes["refid"])
+
+    # pylint: disable-next=missing-function-docstring
+    def depart_target(self, node: nodes.target) -> None:
+        pass
+
+    # Node: reference
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def visit_reference(self, node: nodes.reference) -> None:
+        self._context.top.add_main("[")
+
+    # pylint: disable-next=missing-function-docstring
+    def depart_reference(self, node: nodes.reference) -> None:
+        name: str
+        ref: str
+        if "refuri" in node.attributes:
+            ref = node.attributes["refuri"]
+            name = node.attributes.get("name") or "link"
+        elif "refid" in node.attributes:
+            ref = node.attributes["refid"]
+            name = "reference"
+        else:
+            # docutils fails an assertion at this point
+            raise ValueError(
+                f"Do not know how to handle reference with attributes {node.attributes!r}"
+            )
+        if name == "reference":
+            ref = self._context.global_context.register_label(ref)
+            ref = f"#{ref}"
+        self._context.top.add_main(f"]({_md_escape(ref)})")
+
+    # Node: bullet_list
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def visit_bullet_list(self, node: nodes.bullet_list) -> None:
+        self._context.top.ensure_newline()
+        self._context.push_context(ListContext("- "))
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def depart_bullet_list(self, node: nodes.bullet_list) -> None:
+        self._context.pop_context()
+
+    # Node: enumerated_list
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def visit_enumerated_list(self, node: nodes.enumerated_list) -> None:
+        self._context.top.ensure_newline()
+        self._context.push_context(ListContext("1. "))
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def depart_enumerated_list(self, node: nodes.enumerated_list) -> None:
+        self._context.pop_context()
+
+    # Node: list_item
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def visit_list_item(self, node: nodes.list_item) -> None:
+        list_context = t.cast(ListContext, self._context.top)
+
+        class ListItemContext(Context):
+            """
+            Context for a list item.
+            """
+
+            def close(self) -> None:
+                text = self.get_text().lstrip("\n")
+                self.replace_main()
+                indent = list_context.first_indent
+                for line in text.splitlines():
+                    self.add_main(f"{indent}{line}\n")
+                    indent = list_context.next_indent
+                if not self._main:
+                    self.add_main(f"{indent}\\ \n")
+
+        self._context.push_context(ListItemContext())
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def depart_list_item(self, node: nodes.list_item) -> None:
+        self._context.pop_context()
+
+    # Node: literal_block
+
+    # pylint: disable-next=missing-function-docstring
+    def visit_literal_block(self, node: nodes.literal_block) -> None:
+        self._context.top.ensure_newline()
+        language = get_language_from_literal_block(node)
+
+        class LiteralContext(Context):
+            """
+            Context for a literal block.
+            """
+
+            def __init__(self):
+                super().__init__(escape=False)
+
+            def close(self) -> None:
+                self.ensure_newline()
+                text = self.get_text()
+                backticks_needed = "```"
+                for line in text.splitlines():
+                    if line.startswith(backticks_needed):
+                        backticks_needed = "`" * (count_leading_backticks(line) + 1)
+                self.replace_main(
+                    [
+                        f'{backticks_needed}{language or ""}\n',
+                        text,
+                        f"{backticks_needed}\n",
+                    ]
+                )
+
+        self._context.push_context(LiteralContext())
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def depart_literal_block(self, node: nodes.literal_block) -> None:
+        self._context.pop_context()
+
+    # Node: block_quote
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def visit_block_quote(self, node: nodes.block_quote) -> None:
+        class BlockQuoteContext(Context):
+            """
+            Context for a block quote.
+            """
+
+            def close(self) -> None:
+                self.ensure_newline()
+                lines = self.get_text().splitlines()
+                self.replace_main([f"> {line}\n" for line in lines])
+
+        self._context.push_context(BlockQuoteContext())
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def depart_block_quote(self, node: nodes.block_quote) -> None:
+        self._context.pop_context()
+
+    # Node: system_message
+
+    # pylint: disable-next=missing-function-docstring
+    def visit_system_message(self, node: nodes.system_message) -> None:
+        self._context.top.ensure_newline()
+        self._context.top.add_main("\n<details>\n")
+        message_type = _html_escape(node["type"])
+        message_level = node["level"]
+        source = node["source"]
+        if node.hasattr("line"):
+            source = f'{source}, line {node["line"]}'
+        source = _html_escape(source)
+        self._context.top.add_main(
+            f"<summary><strong>{message_type}/{message_level}</strong> ({source})</summary>\n\n"
+        )
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def depart_system_message(self, node: nodes.system_message) -> None:
+        self._context.top.ensure_newline()
+        self._context.top.add_main("\n</details>\n\n")
+
+    # Node: system_message
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def visit_note(self, node: nodes.note) -> None:
+        class NoteContext(Context):
+            """
+            Context for a note.
+            """
+
+            def close(self) -> None:
+                self.ensure_newline()
+                lines = self.get_text().splitlines()
+                # See https://github.com/orgs/community/discussions/16925 for the syntax
+                self.replace_main(["> [!NOTE]\n"] + [f"> {line}\n" for line in lines])
+
+        self._context.push_context(NoteContext())
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def depart_note(self, node: nodes.note) -> None:
+        self._context.pop_context()
+
+    # Node: topic
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def visit_topic(self, node: nodes.topic) -> None:
+        # The main use of <topic> elements is for Table of Contents
+        class TopicContext(Context):
+            """
+            Context for a topic.
+            """
+
+        self._context.section_depth += 1
+        self._context.push_context(TopicContext())
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def depart_topic(self, node: nodes.topic) -> None:
+        self._context.pop_context()
+        self._context.section_depth -= 1
+
+    # Node: image
+
+    # pylint: disable-next=missing-function-docstring
+    def visit_image(self, node: nodes.image) -> None:
+        self._context.top.ensure_newline()
+        alt = node.attributes.get("alt") or ""
+        uri = node.attributes["uri"]
+        width = node.attributes.get("width")
+        height = node.attributes.get("height")
+        if width is not None or height is not None:
+            # We can only handle width and height with a HTML <img> tag
+            attributes = []
+            if alt:
+                attributes.append(f'alt="{_html_escape(alt)}"')
+            if width:
+                attributes.append(f'width="{_html_escape(str(width))}"')
+            if height:
+                attributes.append(f'height="{_html_escape(str(height))}"')
+            self._context.top.add_main(
+                f'<img src="{_html_escape(uri)}" {" ".join(attributes)}>\n'
+            )
+        else:
+            self._context.top.add_main(f"![{_md_escape(alt)}]({_md_escape(uri)})\n")
+        raise nodes.SkipNode
+
+    # Node: transition
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def visit_transition(self, node: nodes.transition) -> None:
+        self._context.top.ensure_newline()
+        self._context.top.add_main("\n---\n\n")
+        raise nodes.SkipNode
+
+    # Node: title_reference
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def visit_title_reference(self, node: nodes.title_reference) -> None:
+        # This usually happens if someone uses single backticks instead of double backticks
+        self._context.top.add_main('<em class="title-reference">')
+
+    # pylint: disable-next=missing-function-docstring,unused-argument
+    def depart_title_reference(self, node: nodes.title_reference) -> None:
+        self._context.top.add_main("</em>")
+
+    # Node: problematic
+
+    # pylint: disable-next=missing-function-docstring
+    def visit_problematic(self, node):
+        if "refid" in node.attributes:
+            self._context.top.add_main(
+                f'<a href="#{html_escape(node.attributes["refid"])}">'
+            )
+        self._context.top.add_main('<span class="problematic">')
+
+    # pylint: disable-next=missing-function-docstring
+    def depart_problematic(self, node):
+        self._context.top.add_main("</span>")
+        if "refid" in node.attributes:
+            self._context.top.add_main("</a>")
+
+
+class MarkDownWriter(writers.Writer):
+    """
+    Create a MarkDown document from a docutils node tree.
+    """
+
+    def __init__(self, document_context: DocumentContext):
+        writers.Writer.__init__(self)
+        self.document_context = document_context
+        self.translator_class = Translator
+
+    def translate(self) -> None:
+        """
+        Translate the document node tree to MarkDown.
+        """
+        translator = self.translator_class(self.document, self.document_context)
+        self.document.walkabout(translator)
+        self.output = translator.get_text()
+
+
+def render_as_markdown(
+    source: str,
+    /,
+    parser_name: SupportedParser,
+    global_context: GlobalContext | None = None,
+    source_path: str | None = None,
+    destination_path: str | None = None,
+) -> RenderResult:
+    """
+    Render the document as MarkDown.
+    """
+    if global_context is None:
+        global_context = GlobalContext()
+    document_context = DocumentContext(global_context)
+    parts = publish_parts(
+        source=source,
+        source_path=source_path,
+        destination_path=destination_path,
+        parser_name=parser_name,
+        writer=MarkDownWriter(document_context),
+        settings_overrides=_DOCUTILS_PUBLISH_SETTINGS,
+    )
+    return RenderResult(parts["whole"], document_context.unknown_node_types)
+
+
+__all__ = ("GlobalContext", "render_as_markdown")

--- a/src/antsibull_changelog/rendering/markdown.py
+++ b/src/antsibull_changelog/rendering/markdown.py
@@ -127,6 +127,18 @@ class Context:
         if self._main and not self._main[-1].endswith("\n"):
             self._main.append("\n")
 
+    def ensure_double_newline(self) -> None:
+        """
+        Ensure that the main part ends with two newlines, if it is not empty.
+        """
+        if self._main:
+            last = "".join(self._main[:-2])
+            if not last.endswith("\n\n"):
+                if last.endswith("\n"):
+                    self._main.append("\n")
+                else:
+                    self._main.append("\n\n")
+
     def append(
         self,
         context: "Context",
@@ -364,14 +376,11 @@ class Translator(nodes.NodeVisitor):  # pylint: disable=too-many-public-methods
             self._context.top.add_main(text)
         raise nodes.SkipNode
 
-    # pylint: disable-next=missing-function-docstring,unused-argument
-    def depart_title(self, node: nodes.title) -> None:
-        self._context.top.add_main("\n")
-
     # Node: section
 
     # pylint: disable-next=missing-function-docstring
     def visit_section(self, node: nodes.section) -> None:
+        self._context.top.ensure_double_newline()
         if "ids" in node.attributes:
             for ref in node.attributes["ids"]:
                 self._add_label(ref)

--- a/src/antsibull_changelog/rendering/md_document.py
+++ b/src/antsibull_changelog/rendering/md_document.py
@@ -172,12 +172,14 @@ class MDDocumentRenderer(MDAbstractRenderer, DocumentRendererEx):
 
     global_context: GlobalContext
     unsupported_class_names: set[str]
+    warnings: list[str]
 
     def __init__(self, start_level: int = 0):
         super().__init__(root=self)
         DocumentRendererEx.__init__(self, start_level=start_level)
         self.global_context = GlobalContext()
         self.unsupported_class_names = set()
+        self.warnings = []
 
     def _get_level(self) -> int:
         return self.start_level
@@ -194,6 +196,7 @@ class MDDocumentRenderer(MDAbstractRenderer, DocumentRendererEx):
             global_context=self.global_context,
         )
         self.unsupported_class_names.update(result.unsupported_class_names)
+        self.warnings.extend(result.warnings)
         return result.output
 
     def get_ref_id(self, title: str) -> str:
@@ -220,6 +223,7 @@ class MDDocumentRenderer(MDAbstractRenderer, DocumentRendererEx):
                 "Found unsupported docutils class names that could not be converted"
                 f" to MarkDown: {classnames}"
             )
+        result.extend(self.warnings)
         return result
 
 

--- a/src/antsibull_changelog/rendering/md_document.py
+++ b/src/antsibull_changelog/rendering/md_document.py
@@ -21,6 +21,7 @@ from ._document import (
     BaseContent,
     DocumentRendererEx,
     render_document,
+    render_section,
 )
 from .document import SectionRenderer
 from .markdown import GlobalContext, html_escape, md_escape, render_as_markdown
@@ -150,21 +151,7 @@ class MDSectionRenderer(MDAbstractRenderer, SectionRenderer):
             content.append_lines(lines, start_level=start_level)
 
     def render(self) -> str:
-        # Check
-        if not self.closed:
-            raise ValueError(f"Section {self} is not closed")
-
-        # Make sure everything is generated
-        self.generate()
-        for content in self.content:
-            content.generate()
-
-        # Generate lines
-        lines: list[str] = []
-        self.append_lines(lines)
-
-        # Return lines
-        return "\n".join(lines) + "\n"  # add trailing newline
+        return render_section(self)
 
 
 def _get_slug(text: str) -> str:

--- a/src/antsibull_changelog/rendering/md_document.py
+++ b/src/antsibull_changelog/rendering/md_document.py
@@ -1,0 +1,225 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2024, Ansible Project
+
+"""
+Functionality for rendering a MarkDown document.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import cast
+
+from ..fragment import FragmentFormat
+from ._document import (
+    AbstractRendererEx,
+    BaseContent,
+    DocumentRendererEx,
+    render_document,
+)
+from .document import SectionRenderer
+from .markdown import GlobalContext, html_escape, md_escape, render_as_markdown
+from .utils import ensure_newline_after_last_content, get_parser_name
+
+_SPACE_LIKE = re.compile("[ ._-]")
+_DISALLOWED_LETTER = re.compile("[^a-zA-Z0-9-]")
+
+
+@dataclass
+class TOCEntry:
+    """
+    A TOC entry.
+    """
+
+    section: "MDSectionRenderer"
+
+    children: "list[TOCEntry]"
+
+
+class MDTOCRenderer(BaseContent):
+    """
+    Render a Table of contents as MarkDown.
+    """
+
+    owner: "MDAbstractRenderer"
+    title: str | None
+    max_depth: int | None
+    toc: list[TOCEntry] | None
+
+    def __init__(
+        self, owner: "MDAbstractRenderer", title: str | None, max_depth: int | None
+    ):
+        super().__init__(already_closed=True)
+        self.owner = owner
+        self.title = title
+        self.max_depth = max_depth
+        self.toc = None
+
+    def _collect_toc_entries(
+        self, content: list[BaseContent], max_depth: int | None
+    ) -> list[TOCEntry]:
+        result = []
+        for c in content:
+            if isinstance(c, MDSectionRenderer):
+                if max_depth in (0, 1):
+                    children = []
+                else:
+                    children = self._collect_toc_entries(
+                        c.content, None if max_depth is None else (max_depth - 1)
+                    )
+                result.append(TOCEntry(c, children))
+        return result
+
+    def generate(self) -> None:
+        self.toc = self._collect_toc_entries(
+            self.owner.content, max_depth=self.max_depth
+        )
+
+    def _append_toc_entry(self, lines: list[str], entry: TOCEntry, indent: str) -> None:
+        lines.append(f"{indent}- {md_escape(entry.section.title)}")
+        next_indent = f"{indent}  "
+        for child in entry.children:
+            self._append_toc_entry(lines, child, next_indent)
+
+    def append_lines(self, lines: list[str], start_level: int = 0) -> None:
+        toc = self.toc
+        if toc is None:
+            raise ValueError("Forgot to call generate()")
+        if self.title:
+            lines.append(f"**{md_escape(self.title)}**")
+        for entry in toc:
+            self._append_toc_entry(lines, entry, "")
+
+
+class MDAbstractRenderer(AbstractRendererEx):
+    """
+    Abstract MarkDown renderer.
+    """
+
+    def __init__(self, root: DocumentRendererEx):
+        super().__init__(root, "* ")
+
+    def add_section(self, title: str) -> SectionRenderer:
+        if self.closed:
+            raise ValueError("{self} is already closed")
+        section = MDSectionRenderer(self._get_level() + 1, title, self.root)
+        self.content.append(section)
+        return section
+
+    def add_toc(self, title: str | None = None, max_depth: int | None = None) -> None:
+        if self.closed:
+            raise ValueError("{self} is already closed")
+        self.content.append(MDTOCRenderer(self, title, max_depth))
+
+
+class MDSectionRenderer(MDAbstractRenderer, SectionRenderer):
+    """
+    Render a section as MarkDown.
+    """
+
+    _level: int
+
+    title: str
+    ref_id: str
+
+    def __init__(self, level: int, title: str, root: DocumentRendererEx):
+        super().__init__(root=root)
+        self._level = level
+        self.title = title
+        self.ref_id = cast(MDDocumentRenderer, self.root).get_ref_id(self.title)
+
+    def _get_level(self) -> int:
+        return self._level
+
+    def close(self) -> None:
+        self._check_content_closed()
+        self.closed = True
+
+    def append_lines(self, lines: list[str], start_level: int = 0) -> None:
+        ensure_newline_after_last_content(lines)
+        heading = "#" * (1 + self._level - start_level)
+        lines.append(f'<a id="{html_escape(self.ref_id)}"></a>')
+        lines.append(f"{heading} {md_escape(self.title)}")
+        lines.append("")
+        for content in self.content:
+            content.append_lines(lines, start_level=start_level)
+
+    def render(self) -> str:
+        # Check
+        if not self.closed:
+            raise ValueError(f"Section {self} is not closed")
+
+        # Make sure everything is generated
+        self.generate()
+        for content in self.content:
+            content.generate()
+
+        # Generate lines
+        lines: list[str] = []
+        self.append_lines(lines)
+
+        # Return lines
+        return "\n".join(lines) + "\n"  # add trailing newline
+
+
+def _get_slug(text: str) -> str:
+    text = unicodedata.normalize("NFD", text)
+    text = _SPACE_LIKE.sub("-", text)
+    text = _DISALLOWED_LETTER.sub("", text)
+    return text
+
+
+class MDDocumentRenderer(MDAbstractRenderer, DocumentRendererEx):
+    """
+    Render a document as MarkDown.
+    """
+
+    global_context: GlobalContext
+    unsupported_class_names: set[str]
+
+    def __init__(self, start_level: int = 0):
+        super().__init__(root=self)
+        DocumentRendererEx.__init__(self, start_level=start_level)
+        self.global_context = GlobalContext()
+        self.unsupported_class_names = set()
+
+    def _get_level(self) -> int:
+        return self.start_level
+
+    def render_text(self, text: str, text_format: FragmentFormat) -> str:
+        """
+        Render a text as MarkDown.
+        """
+        if text_format == FragmentFormat.MARKDOWN:
+            return text
+        result = render_as_markdown(
+            text,
+            parser_name=get_parser_name(text_format),
+            global_context=self.global_context,
+        )
+        self.unsupported_class_names.update(result.unsupported_class_names)
+        return result.output
+
+    def get_ref_id(self, title: str) -> str:
+        """
+        Create a reference ID for a section title.
+        """
+        return self.global_context.register_new_fragment(_get_slug(title))
+
+    def append_lines(self, lines: list[str], start_level: int = 0) -> None:
+        if self.title is not None:
+            lines.append(f"# {md_escape(self.title or '')}")
+            lines.append("")
+        for content in self.content:
+            content.append_lines(lines, start_level=start_level)
+
+    def render(self) -> str:
+        return render_document(self, self)
+
+
+__all__ = ("MDDocumentRenderer",)

--- a/src/antsibull_changelog/rendering/md_document.py
+++ b/src/antsibull_changelog/rendering/md_document.py
@@ -94,6 +94,7 @@ class MDTOCRenderer(BaseContent):
         toc = self.toc
         if toc is None:
             raise ValueError("Forgot to call generate()")
+        ensure_newline_after_last_content(lines)
         if self.title:
             lines.append(f"**{md_escape(self.title)}**")
         for entry in toc:

--- a/src/antsibull_changelog/rendering/md_document.py
+++ b/src/antsibull_changelog/rendering/md_document.py
@@ -61,8 +61,9 @@ class MDTOCRenderer(BaseContent):
         self.max_depth = max_depth
         self.toc = None
 
+    @staticmethod
     def _collect_toc_entries(
-        self, content: list[BaseContent], max_depth: int | None
+        content: list[BaseContent], max_depth: int | None
     ) -> list[TOCEntry]:
         result = []
         for c in content:
@@ -70,7 +71,7 @@ class MDTOCRenderer(BaseContent):
                 if max_depth in (0, 1):
                     children = []
                 else:
-                    children = self._collect_toc_entries(
+                    children = MDTOCRenderer._collect_toc_entries(
                         c.content, None if max_depth is None else (max_depth - 1)
                     )
                 result.append(TOCEntry(c, children))

--- a/src/antsibull_changelog/rendering/rst.py
+++ b/src/antsibull_changelog/rendering/rst.py
@@ -1,0 +1,44 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2024, Ansible Project
+
+"""
+Functionality for rendering a ReStructuredText document.
+"""
+
+from __future__ import annotations
+
+from docutils.utils import column_width as _column_width  # pyre-ignore[21]
+
+
+def rst_escape(value: str, escape_ending_whitespace=False) -> str:
+    """
+    Escape RST specific constructs.
+    """
+    value = value.replace("\\", "\\\\")
+    value = value.replace("<", "\\<")
+    value = value.replace(">", "\\>")
+    value = value.replace("_", "\\_")
+    value = value.replace("*", "\\*")
+    value = value.replace("`", "\\`")
+
+    if escape_ending_whitespace and value.endswith(" "):
+        value = value + "\\ "
+    if escape_ending_whitespace and value.startswith(" "):
+        value = "\\ " + value
+
+    return value
+
+
+def column_width(string: str) -> int:
+    """
+    Return column width of string.
+
+    This is needed for title under- and overlines.
+    """
+    return _column_width(string)
+
+
+__ALL__ = ("rst_escape", "column_width")

--- a/src/antsibull_changelog/rendering/rst.py
+++ b/src/antsibull_changelog/rendering/rst.py
@@ -41,4 +41,4 @@ def column_width(string: str) -> int:
     return _column_width(string)
 
 
-__ALL__ = ("rst_escape", "column_width")
+__all__ = ("rst_escape", "column_width")

--- a/src/antsibull_changelog/rendering/rst_document.py
+++ b/src/antsibull_changelog/rendering/rst_document.py
@@ -161,6 +161,7 @@ class RSTDocumentRenderer(RSTAbstractRenderer, DocumentRendererEx):
             line = "=" * column_width(title)
             if self.document_label:
                 lines.append(f".. _{self.document_label}:")
+                lines.append("")
             lines.append(line)
             lines.append(title)
             lines.append(line)

--- a/src/antsibull_changelog/rendering/rst_document.py
+++ b/src/antsibull_changelog/rendering/rst_document.py
@@ -1,0 +1,162 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2024, Ansible Project
+
+"""
+Functionality for rendering a ReStructuredText document.
+"""
+
+from __future__ import annotations
+
+from ..fragment import FragmentFormat
+from ._document import (
+    AbstractRendererEx,
+    BaseContent,
+    DocumentRendererEx,
+    render_document,
+)
+from .document import SectionRenderer
+from .rst import column_width, rst_escape
+from .utils import ensure_newline_after_last_content
+
+_SECTION_UNDERLINES = """=-~^.*+:`'"_#"""
+
+
+class RSTTOCRenderer(BaseContent):
+    """
+    Render a Table of contents as RST.
+    """
+
+    title: str | None
+    max_depth: int | None
+
+    def __init__(self, title: str | None, max_depth: int | None):
+        super().__init__(already_closed=True)
+        self.title = title
+        self.max_depth = max_depth
+
+    def append_lines(self, lines: list[str], start_level: int = 0) -> None:
+        if self.title:
+            lines.append(f".. contents:: {rst_escape(self.title)}")
+        else:
+            lines.append(".. contents::")
+        if start_level:
+            lines.append("  :local:")
+        if self.max_depth is not None:
+            lines.append("  :depth: {self.max_depth}")
+        lines.append("")
+        lines.append("")
+
+
+class RSTAbstractRenderer(AbstractRendererEx):
+    """
+    Abstract RST renderer.
+    """
+
+    def __init__(self, root: DocumentRendererEx):
+        super().__init__(root, "- ")
+
+    def add_section(self, title: str) -> SectionRenderer:
+        if self.closed:
+            raise ValueError("{self} is already closed")
+        section = RSTSectionRenderer(self._get_level() + 1, title, self.root)
+        self.content.append(section)
+        return section
+
+    def add_toc(self, title: str | None = None, max_depth: int | None = None) -> None:
+        if self.closed:
+            raise ValueError("{self} is already closed")
+        self.content.append(RSTTOCRenderer(title, max_depth))
+
+
+class RSTSectionRenderer(RSTAbstractRenderer, SectionRenderer):
+    """
+    Render a section as RST.
+    """
+
+    _level: int
+
+    title: str
+
+    def __init__(self, level: int, title: str, root: DocumentRendererEx):
+        super().__init__(root=root)
+        self._level = level
+        self.title = title
+
+    def _get_level(self) -> int:
+        return self._level
+
+    def close(self) -> None:
+        self._check_content_closed()
+        self.closed = True
+
+    def append_lines(self, lines: list[str], start_level: int = 0) -> None:
+        ensure_newline_after_last_content(lines)
+        level = max(0, self._level - 1)
+        lines.append(self.title)
+        lines.append(_SECTION_UNDERLINES[level] * column_width(self.title))
+        lines.append("")
+        for content in self.content:
+            content.append_lines(lines, start_level=start_level)
+
+    def render(self) -> str:
+        # Check
+        if not self.closed:
+            raise ValueError(f"Section {self} is not closed")
+
+        # Make sure everything is generated
+        self.generate()
+        for content in self.content:
+            content.generate()
+
+        # Generate lines
+        lines: list[str] = []
+        self.append_lines(lines)
+
+        # Return lines
+        return "\n".join(lines) + "\n"  # add trailing newline
+
+
+class RSTDocumentRenderer(RSTAbstractRenderer, DocumentRendererEx):
+    """
+    Render a document as RST.
+    """
+
+    unsupported_class_names: set[str]
+
+    def __init__(self, start_level: int = 0):
+        super().__init__(root=self)
+        DocumentRendererEx.__init__(self, start_level=start_level)
+        self.unsupported_class_names = set()
+
+    def _get_level(self) -> int:
+        return self.start_level
+
+    def render_text(self, text: str, text_format: FragmentFormat) -> str:
+        """
+        Render a text as ReStructured Text.
+        """
+        if text_format == FragmentFormat.RESTRUCTURED_TEXT:
+            return text
+        raise ValueError(
+            f"Text format {text_format} is currently not supported in RST documents!"
+        )
+
+    def append_lines(self, lines: list[str], start_level: int = 0) -> None:
+        if self.title is not None:
+            title = rst_escape(self.title)
+            line = "=" * column_width(title)
+            lines.append(line)
+            lines.append(title)
+            lines.append(line)
+            lines.append("")
+        for content in self.content:
+            content.append_lines(lines, start_level=start_level)
+
+    def render(self) -> str:
+        return render_document(self, self)
+
+
+__all__ = ("RSTDocumentRenderer",)

--- a/src/antsibull_changelog/rendering/rst_document.py
+++ b/src/antsibull_changelog/rendering/rst_document.py
@@ -16,6 +16,7 @@ from ._document import (
     BaseContent,
     DocumentRendererEx,
     render_document,
+    render_section,
 )
 from .document import SectionRenderer
 from .rst import column_width, rst_escape
@@ -102,21 +103,7 @@ class RSTSectionRenderer(RSTAbstractRenderer, SectionRenderer):
             content.append_lines(lines, start_level=start_level)
 
     def render(self) -> str:
-        # Check
-        if not self.closed:
-            raise ValueError(f"Section {self} is not closed")
-
-        # Make sure everything is generated
-        self.generate()
-        for content in self.content:
-            content.generate()
-
-        # Generate lines
-        lines: list[str] = []
-        self.append_lines(lines)
-
-        # Return lines
-        return "\n".join(lines) + "\n"  # add trailing newline
+        return render_section(self)
 
 
 class RSTDocumentRenderer(RSTAbstractRenderer, DocumentRendererEx):

--- a/src/antsibull_changelog/rendering/rst_document.py
+++ b/src/antsibull_changelog/rendering/rst_document.py
@@ -10,7 +10,7 @@ Functionality for rendering a ReStructuredText document.
 
 from __future__ import annotations
 
-from ..fragment import FragmentFormat
+from ..config import TextFormat
 from ._document import (
     AbstractRendererEx,
     BaseContent,
@@ -121,11 +121,11 @@ class RSTDocumentRenderer(RSTAbstractRenderer, DocumentRendererEx):
     def _get_level(self) -> int:
         return self.start_level
 
-    def render_text(self, text: str, text_format: FragmentFormat) -> str:
+    def render_text(self, text: str, text_format: TextFormat) -> str:
         """
         Render a text as ReStructured Text.
         """
-        if text_format == FragmentFormat.RESTRUCTURED_TEXT:
+        if text_format == TextFormat.RESTRUCTURED_TEXT:
             return text
         raise ValueError(
             f"Text format {text_format} is currently not supported in RST documents!"
@@ -144,6 +144,9 @@ class RSTDocumentRenderer(RSTAbstractRenderer, DocumentRendererEx):
 
     def render(self) -> str:
         return render_document(self, self)
+
+    def get_warnings(self) -> list[str]:
+        return []
 
 
 __all__ = ("RSTDocumentRenderer",)

--- a/src/antsibull_changelog/rendering/utils.py
+++ b/src/antsibull_changelog/rendering/utils.py
@@ -2,7 +2,7 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
 # https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
-# SPDX-FileCopyrightText: 2022, Ansible Project
+# SPDX-FileCopyrightText: 2024, Ansible Project
 
 """
 Utility code for rendering.
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from docutils.core import publish_parts
 from docutils.utils import Reporter as DocutilsReporter
 
+from ..fragment import FragmentFormat
+
 SupportedParser = t.Union[t.Literal["restructuredtext"], t.Literal["markdown"]]
 
 
@@ -28,6 +30,17 @@ _DOCUTILS_PUBLISH_SETTINGS = {
     "_disable_config": True,
     "report_level": DocutilsReporter.SEVERE_LEVEL + 1,
 }
+
+
+def get_parser_name(text_format: FragmentFormat) -> SupportedParser:
+    """
+    Convert a FragmentFormat to a docutils parser name.
+    """
+    if text_format == FragmentFormat.MARKDOWN:
+        return "markdown"
+    if text_format == FragmentFormat.RESTRUCTURED_TEXT:
+        return "restructuredtext"
+    raise ValueError(f"Unsupported format {format}")
 
 
 @dataclass
@@ -57,4 +70,17 @@ def get_document_structure(
     return RenderResult(parts["whole"], set())
 
 
-__all__ = ("SupportedParser", "RenderResult", "get_document_structure")
+def ensure_newline_after_last_content(lines: list[str]) -> None:
+    """
+    Ensure that if ``lines`` is not empty, the last entry is ``""``.
+    """
+    if lines and lines[-1] != "":
+        lines.append("")
+
+
+__all__ = (
+    "SupportedParser",
+    "RenderResult",
+    "get_document_structure",
+    "ensure_newline_after_last_content",
+)

--- a/src/antsibull_changelog/rendering/utils.py
+++ b/src/antsibull_changelog/rendering/utils.py
@@ -1,0 +1,60 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2022, Ansible Project
+
+"""
+Utility code for rendering.
+"""
+
+# pyre-ignore-all-errors
+
+from __future__ import annotations
+
+import typing as t
+from dataclasses import dataclass
+
+from docutils.core import publish_parts
+from docutils.utils import Reporter as DocutilsReporter
+
+SupportedParser = t.Union[t.Literal["restructuredtext"], t.Literal["markdown"]]
+
+
+_DOCUTILS_PUBLISH_SETTINGS = {
+    "input_encoding": "unicode",
+    "file_insertion_enabled": False,
+    "raw_enabled": False,
+    "_disable_config": True,
+    "report_level": DocutilsReporter.SEVERE_LEVEL + 1,
+}
+
+
+@dataclass
+class RenderResult:
+    """
+    A rendering result.
+    """
+
+    # The output of the renderer.
+    output: str
+
+    # The set of class names found that weren't supported by this renderer.
+    unsupported_class_names: set[str]
+
+
+def get_document_structure(
+    source: str, /, parser_name: SupportedParser
+) -> RenderResult:
+    """
+    Render the document as its internal docutils structure.
+    """
+    parts = publish_parts(
+        source=source,
+        parser_name=parser_name,
+        settings_overrides=_DOCUTILS_PUBLISH_SETTINGS,
+    )
+    return RenderResult(parts["whole"], set())
+
+
+__all__ = ("SupportedParser", "RenderResult", "get_document_structure")

--- a/src/antsibull_changelog/rendering/utils.py
+++ b/src/antsibull_changelog/rendering/utils.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from docutils.core import publish_parts
 from docutils.utils import Reporter as DocutilsReporter
 
-from ..fragment import FragmentFormat
+from ..config import TextFormat
 
 SupportedParser = t.Union[t.Literal["restructuredtext"], t.Literal["markdown"]]
 
@@ -32,13 +32,13 @@ _DOCUTILS_PUBLISH_SETTINGS = {
 }
 
 
-def get_parser_name(text_format: FragmentFormat) -> SupportedParser:
+def get_parser_name(text_format: TextFormat) -> SupportedParser:
     """
-    Convert a FragmentFormat to a docutils parser name.
+    Convert a TextFormat to a docutils parser name.
     """
-    if text_format == FragmentFormat.MARKDOWN:
+    if text_format == TextFormat.MARKDOWN:
         return "markdown"
-    if text_format == FragmentFormat.RESTRUCTURED_TEXT:
+    if text_format == TextFormat.RESTRUCTURED_TEXT:
         return "restructuredtext"
     raise ValueError(f"Unsupported format {format}")
 

--- a/src/antsibull_changelog/rst.py
+++ b/src/antsibull_changelog/rst.py
@@ -6,6 +6,8 @@
 
 """
 ReStructuredText helpers.
+
+This module is DEPRECATED! It will be removed in a future version.
 """
 
 from __future__ import annotations
@@ -14,6 +16,8 @@ from __future__ import annotations
 class RstBuilder:
     """
     Simple reStructuredText (RST) builder.
+
+    This class is DEPRECATED! It will be removed in a future version.
     """
 
     lines: list[str]

--- a/tests/functional/test_changelog_archive.py
+++ b/tests/functional/test_changelog_archive.py
@@ -59,7 +59,6 @@ Ansible 1.0 Release Notes
 
 .. contents:: Topics
 
-
 v1.0.0
 ======
 
@@ -99,7 +98,6 @@ Ansible 1.0 Release Notes
 =========================
 
 .. contents:: Topics
-
 
 v1.0.0
 ======
@@ -164,7 +162,6 @@ Ansible 1.0 Release Notes
 
 .. contents:: Topics
 
-
 v1.0.0
 ======
 
@@ -214,7 +211,6 @@ Ansible 1.1 Release Notes
 =========================
 
 .. contents:: Topics
-
 
 v1.1.0
 ======
@@ -271,7 +267,6 @@ Ansible 1.2 Release Notes
 =========================
 
 .. contents:: Topics
-
 
 v1.2.0
 ======
@@ -353,7 +348,6 @@ Ansible 1.0 Release Notes
 
 .. contents:: Topics
 
-
 v1.0.0
 ======
 
@@ -394,7 +388,6 @@ Ansible 1.0 Release Notes
 =========================
 
 .. contents:: Topics
-
 
 v1.0.0
 ======

--- a/tests/functional/test_changelog_basic_ansible.py
+++ b/tests/functional/test_changelog_basic_ansible.py
@@ -85,7 +85,6 @@ Ansible Base 2.10 "meow" Release Notes
 
 .. contents:: Topics
 
-
 v2.10
 =====
 
@@ -137,7 +136,6 @@ Ansible Base 2.10 "meow" Release Notes
 ======================================
 
 .. contents:: Topics
-
 
 v2.10.1
 =======
@@ -288,7 +286,6 @@ Ansible Base 2.10 "meow" Release Notes
 
 .. contents:: Topics
 
-
 v2.10
 =====
 
@@ -423,7 +420,6 @@ Ansible Base 2.10 "meow" Release Notes
 
 .. contents:: Topics
 
-
 v2.10
 =====
 
@@ -556,7 +552,6 @@ Ansible Base 2.10 "woof" Release Notes
 ======================================
 
 .. contents:: Topics
-
 
 v2.10.1b1
 =========
@@ -729,7 +724,6 @@ Ansible Base 2.10 "woof!" Release Notes
 =======================================
 
 .. contents:: Topics
-
 
 v2.10.1
 =======
@@ -1129,7 +1123,6 @@ Ansible Base 2.10 "meow" Release Notes
 ======================================
 
 .. contents:: Topics
-
 
 v2.10
 =====

--- a/tests/functional/test_changelog_basic_ansible_classic.py
+++ b/tests/functional/test_changelog_basic_ansible_classic.py
@@ -93,7 +93,6 @@ Ansible 2.9 "meow" Release Notes
 
 .. contents:: Topics
 
-
 v2.9
 ====
 
@@ -145,7 +144,6 @@ Ansible 2.9 "meow" Release Notes
 ================================
 
 .. contents:: Topics
-
 
 v2.9.1
 ======
@@ -271,7 +269,6 @@ Ansible 2.9 "meow" Release Notes
 
 .. contents:: Topics
 
-
 v2.9
 ====
 
@@ -386,7 +383,6 @@ Ansible 2.9 "meow" Release Notes
 ================================
 
 .. contents:: Topics
-
 
 v2.9
 ====
@@ -508,7 +504,6 @@ Ansible 2.9 "woof" Release Notes
 ================================
 
 .. contents:: Topics
-
 
 v2.9.1b1
 ========
@@ -665,7 +660,6 @@ Ansible 2.9 "woof!" Release Notes
 =================================
 
 .. contents:: Topics
-
 
 v2.9.1
 ======
@@ -1036,7 +1030,6 @@ Ansible 2.9 "meow" Release Notes
 ================================
 
 .. contents:: Topics
-
 
 v2.9
 ====

--- a/tests/functional/test_changelog_basic_collection.py
+++ b/tests/functional/test_changelog_basic_collection.py
@@ -137,6 +137,14 @@ This is the first proper release\.
 
     assert (
         collection_changelog.run_tool(
+            "generate", ["-v", "--refresh", "--output", "CHANGELOG.md"]
+        )
+        == 5
+    )
+    assert collection_changelog.diff().unchanged
+
+    assert (
+        collection_changelog.run_tool(
             "release", ["-v", "--codename", "primetime", "--date", "2020-01-03"]
         )
         == 0
@@ -1382,6 +1390,57 @@ New Modules
 - acme.test.test_new - This is ANOTHER test module
 - acme.test.test_new2 - This is ANOTHER test module!!!11
 - acme.test.test_new3 - This is yet another test module.
+"""
+    )
+
+    # Generate changelog for 1.0.0 only as MD
+    assert (
+        collection_changelog.run_tool(
+            "generate",
+            [
+                "-vvv",
+                "--output",
+                "changelog-1.0.0.md",
+                "--output-format",
+                "md",
+                "--only-latest",
+                "1.0.0",
+            ],
+        )
+        == 0
+    )
+
+    diff = collection_changelog.diff()
+    assert diff.added_dirs == []
+    assert diff.added_files == ["changelog-1.0.0.md"]
+    assert diff.removed_dirs == []
+    assert diff.removed_files == []
+    assert diff.changed_files == []
+
+    assert diff.file_contents["changelog-1.0.0.md"].decode("utf-8") == (
+        r"""<a id="release-summary"></a>
+## Release Summary
+
+This is the first proper release\.
+
+<a id="minor-changes"></a>
+## Minor Changes
+
+* baz lookup \- no longer ignores the <code>bar</code> option\.
+* test \- has a new option <code>foo</code>\.
+
+<a id="new-plugins"></a>
+## New Plugins
+
+<a id="lookup"></a>
+### Lookup
+
+* acme\.test\.bar \- A foo\_bar lookup
+
+<a id="new-modules"></a>
+## New Modules
+
+* acme\.test\.test \- This is a TEST module
 """
     )
 

--- a/tests/functional/test_changelog_basic_collection.py
+++ b/tests/functional/test_changelog_basic_collection.py
@@ -96,7 +96,6 @@ Ansible Release Notes
 
 .. contents:: Topics
 
-
 v1.0.0
 ======
 
@@ -150,7 +149,6 @@ Ansible "primetime" Release Notes
 
 .. contents:: Topics
 
-
 v1.0.0
 ======
 
@@ -196,7 +194,6 @@ Ansible Release Notes
 =====================
 
 .. contents:: Topics
-
 
 v1.1.0
 ======
@@ -339,7 +336,6 @@ Ansible 1.0 Release Notes
 
 .. contents:: Topics
 
-
 v1.0.0
 ======
 
@@ -457,7 +453,6 @@ Ansible 1.0 Release Notes
 =========================
 
 .. contents:: Topics
-
 
 v1.0.0
 ======
@@ -589,7 +584,6 @@ Ansible 1.1 Release Notes
 =========================
 
 .. contents:: Topics
-
 
 v1.1.0-beta-1
 =============
@@ -772,7 +766,6 @@ Ansible 1.1 Release Notes
 =========================
 
 .. contents:: Topics
-
 
 v1.1.0
 ======
@@ -1053,7 +1046,6 @@ Ansible 1.2 Release Notes
 
 .. contents:: Topics
 
-
 v1.2.0
 ======
 
@@ -1217,7 +1209,6 @@ Ansible 1.1 Release Notes
 =========================
 
 .. contents:: Topics
-
 
 v1.1.0
 ======
@@ -1608,7 +1599,6 @@ Test Collection Release Notes
 =============================
 
 .. contents:: Topics
-
 
 v1.0.0
 ======
@@ -2036,7 +2026,6 @@ My Amazing Collection Release Notes
 ===================================
 
 .. contents:: Topics
-
 
 v1.0.0
 ======

--- a/tests/functional/test_changelog_basic_collection.py
+++ b/tests/functional/test_changelog_basic_collection.py
@@ -16,6 +16,7 @@ from fixtures import collection_changelog  # noqa: F401; pylint: disable=unused-
 from fixtures import create_plugin
 
 import antsibull_changelog.ansible  # noqa: F401; pylint: disable=unused-variable
+from antsibull_changelog.config import TextFormat
 
 
 def test_changelog_init(  # pylint: disable=redefined-outer-name
@@ -55,6 +56,10 @@ def test_changelog_release_empty(  # pylint: disable=redefined-outer-name
             "version": "1.0.0",
         }
     )
+    collection_changelog.config.output_formats = {
+        TextFormat.RESTRUCTURED_TEXT,
+        TextFormat.MARKDOWN,
+    }
     collection_changelog.set_config(collection_changelog.config)
     collection_changelog.add_fragment_line(
         "1.0.0.yml", "release_summary", "This is the first proper release."
@@ -68,7 +73,11 @@ def test_changelog_release_empty(  # pylint: disable=redefined-outer-name
 
     diff = collection_changelog.diff()
     assert diff.added_dirs == []
-    assert diff.added_files == ["CHANGELOG.rst", "changelogs/changelog.yaml"]
+    assert diff.added_files == [
+        "CHANGELOG.md",
+        "CHANGELOG.rst",
+        "changelogs/changelog.yaml",
+    ]
     assert diff.removed_dirs == []
     assert diff.removed_files == [
         "changelogs/fragments/1.0.0.yml",
@@ -106,6 +115,23 @@ This is the first proper release.
 """
     )
 
+    assert diff.file_contents["CHANGELOG.md"].decode("utf-8") == (
+        r"""# Ansible Release Notes
+
+**Topics**
+- <a href="#v1-0-0">v1\.0\.0</a>
+  - <a href="#release-summary">Release Summary</a>
+
+<a id="v1-0-0"></a>
+## v1\.0\.0
+
+<a id="release-summary"></a>
+### Release Summary
+
+This is the first proper release\.
+"""
+    )
+
     assert collection_changelog.run_tool("generate", ["-v", "--refresh"]) == 0
     assert collection_changelog.diff().unchanged
 
@@ -136,7 +162,11 @@ This is the first proper release.
     assert diff.added_files == []
     assert diff.removed_dirs == []
     assert diff.removed_files == []
-    assert diff.changed_files == ["CHANGELOG.rst", "changelogs/changelog.yaml"]
+    assert diff.changed_files == [
+        "CHANGELOG.md",
+        "CHANGELOG.rst",
+        "changelogs/changelog.yaml",
+    ]
 
     changelog = diff.parse_yaml("changelogs/changelog.yaml")
     assert changelog["releases"]["1.0.0"]["release_date"] == "2020-01-03"
@@ -159,6 +189,23 @@ This is the first proper release.
 """
     )
 
+    assert diff.file_contents["CHANGELOG.md"].decode("utf-8") == (
+        r"""# Ansible \"primetime\" Release Notes
+
+**Topics**
+- <a href="#v1-0-0">v1\.0\.0</a>
+  - <a href="#release-summary">Release Summary</a>
+
+<a id="v1-0-0"></a>
+## v1\.0\.0
+
+<a id="release-summary"></a>
+### Release Summary
+
+This is the first proper release\.
+"""
+    )
+
     # Version 1.1.0
 
     collection_changelog.set_galaxy(
@@ -175,7 +222,11 @@ This is the first proper release.
     assert diff.added_files == []
     assert diff.removed_dirs == []
     assert diff.removed_files == []
-    assert diff.changed_files == ["CHANGELOG.rst", "changelogs/changelog.yaml"]
+    assert diff.changed_files == [
+        "CHANGELOG.md",
+        "CHANGELOG.rst",
+        "changelogs/changelog.yaml",
+    ]
 
     changelog = diff.parse_yaml("changelogs/changelog.yaml")
     assert changelog["ancestor"] is None
@@ -205,6 +256,27 @@ Release Summary
 ---------------
 
 This is the first proper release.
+"""
+    )
+
+    assert diff.file_contents["CHANGELOG.md"].decode("utf-8") == (
+        r"""# Ansible Release Notes
+
+**Topics**
+- <a href="#v1-1-0">v1\.1\.0</a>
+- <a href="#v1-0-0">v1\.0\.0</a>
+  - <a href="#release-summary">Release Summary</a>
+
+<a id="v1-1-0"></a>
+## v1\.1\.0
+
+<a id="v1-0-0"></a>
+## v1\.0\.0
+
+<a id="release-summary"></a>
+### Release Summary
+
+This is the first proper release\.
 """
     )
 

--- a/tests/functional/test_changelog_basic_other.py
+++ b/tests/functional/test_changelog_basic_other.py
@@ -101,7 +101,6 @@ A Random Project Release Notes
 
 .. contents:: Topics
 
-
 v1.0.0
 ======
 
@@ -166,7 +165,6 @@ A Random Project "primetime" Release Notes
 
 .. contents:: Topics
 
-
 v1.0.0
 ======
 
@@ -210,7 +208,6 @@ A Random Project Release Notes
 ==============================
 
 .. contents:: Topics
-
 
 v1.1.0
 ======
@@ -296,7 +293,6 @@ A Random Project 1.0 Release Notes
 
 .. contents:: Topics
 
-
 v1.0.0
 ======
 
@@ -348,7 +344,6 @@ A Random Project 1.0 Release Notes
 ==================================
 
 .. contents:: Topics
-
 
 v1.0.0
 ======
@@ -421,7 +416,6 @@ A Random Project 1.1 Release Notes
 ==================================
 
 .. contents:: Topics
-
 
 v1.1.0-beta-1
 =============
@@ -524,7 +518,6 @@ A Random Project 1.1 Release Notes
 
 .. contents:: Topics
 
-
 v1.1.0
 ======
 
@@ -623,7 +616,6 @@ A Random Project 1.2 Release Notes
 ==================================
 
 .. contents:: Topics
-
 
 v1.2.0
 ======
@@ -764,7 +756,6 @@ A Random Project 1.0 Release Notes
 
 .. contents:: Topics
 
-
 v1.0.0
 ======
 
@@ -854,7 +845,6 @@ A Random Project 1.0 Release Notes
 ==================================
 
 .. contents:: Topics
-
 
 v1.0.0
 ======
@@ -949,7 +939,6 @@ A Random Project 1.0 Release Notes
 ==================================
 
 .. contents:: Topics
-
 
 v1.0.0
 ======

--- a/tests/functional/test_rendering.py
+++ b/tests/functional/test_rendering.py
@@ -354,8 +354,46 @@ A list table:
 
 Regular table\:
 
-A list table\:""",
-        {"table"},
+<table>
+<thead>
+<tr><th class="head"><p>Foo</p></th>
+<th class="head"><p>Bar</p></th>
+</tr>
+</thead>
+<tbody>
+<tr><td><p>A</p></td>
+<td><p>B</p></td>
+</tr>
+<tr><td><p>C</p></td>
+<td><p>D
+DD</p>
+<p>DDD</p>
+</td>
+</tr>
+</tbody>
+</table>
+
+A list table\:
+
+<table style="width: 100%;">
+<thead>
+<tr><th class="head"><p>Foo</p></th>
+<th class="head"><p>Bar</p></th>
+</tr>
+</thead>
+<tbody>
+<tr><td><p>A</p></td>
+<td><p>B</p></td>
+</tr>
+<tr><td><p>C</p></td>
+<td><p>D</p>
+<p>DD</p>
+<p>DDD</p>
+</td>
+</tr>
+</tbody>
+</table>""",
+        set(),
     ),
 ]
 

--- a/tests/functional/test_rendering.py
+++ b/tests/functional/test_rendering.py
@@ -1,0 +1,283 @@
+# Author: Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2024, Ansible Project
+
+"""
+Test rendering code.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from antsibull_changelog.config import TextFormat
+from antsibull_changelog.rendering.markdown import render_as_markdown
+from antsibull_changelog.rendering.utils import get_document_structure
+
+RENDER_AS_MARKDOWN_AND_STRUCTURE_DATA = [
+    (
+        "empty",
+        r"""""",
+        "restructuredtext",
+        r"""""",
+        set(),
+    ),
+    (
+        "simple-rst",
+        r"""`This` *is* **a** `simple <This>`_ `test <https://example.com>`__.""",
+        "restructuredtext",
+        r"""<em class="title-reference">This</em> <em>is</em> <strong>a</strong> [simple](This) [test](https\://example\.com)\.""",
+        set(),
+    ),
+    (
+        "complex-rst",
+        r"""
+==========
+Main title
+==========
+
+Some text.
+
+.. sectnum::
+.. contents:: Table of Contents
+
+.. _label:
+.. _label_2:
+
+This is a subtitle
+^^^^^^^^^^^^^^^^^^
+
+Some test with ``code``.
+Some *emphasis* and **bold** text.
+
+A `link <https://ansible.com/)>`__.
+
+A `reference <label>`_.
+
+A list:
+
+* Item 1.
+* Item 2.
+
+  This is still item 2.
+* Item 3.
+
+An enumeration:
+
+1. Entry 1
+
+   More of Entry 1
+2. Entry 2
+3. Entry 3
+   Second line of entry 3
+
+   - Sublist
+   - Another entry
+
+     1. Subenum
+     
+        .. code:: markdown
+
+            Some codeblock:
+            ```python
+            def main(argv): ...
+            ```
+
+     2. Another entry
+
+Another subtitle
+^^^^^^^^^^^^^^^^
+
+Some code:
+
+.. code:: python
+
+    def main(argv):
+        if argv[1] == 'help':
+            print('Help!')
+
+.. note::
+
+  Some note.
+  
+  This note has two paragraphs.
+
+.. Trigger a system message:
+
+.. unknown-shit::
+
+  Something.
+
+A sub-sub-title
+~~~~~~~~~~~~~~~
+
+Some text...
+
+  Some block quote.
+
+    A nested block quote.
+
+--------
+
+Some unformatted code::
+
+    foo bar!
+    baz bam.
+""",
+        "restructuredtext",
+        r"""# Main title
+
+
+Some text\.
+## Table of Contents
+
+- [1   This is a subtitle](\#this\-is\-a\-subtitle)
+- [2   Another subtitle](\#another\-subtitle)
+  - [2\.1   A sub\-sub\-title](\#a\-sub\-sub\-title)
+<a id="label"></a>
+<a id="label-2"></a>
+<a id="this-is-a-subtitle"></a>
+## 1   This is a subtitle
+
+
+Some test with <code>code</code>\.
+Some <em>emphasis</em> and <strong>bold</strong> text\.
+
+A [link](https\://ansible\.com/\))\.
+
+A [reference](\#label)\.
+
+A list\:
+- Item 1\.
+- Item 2\.
+  
+  This is still item 2\.
+- Item 3\.
+
+An enumeration\:
+1. Entry 1
+   
+   More of Entry 1
+1. Entry 2
+1. Entry 3
+   Second line of entry 3
+   - Sublist
+   - Another entry
+     1. Subenum
+        ````markdown
+        Some codeblock:
+        ```python
+        def main(argv): ...
+        ```
+        ````
+     1. Another entry
+<a id="another-subtitle"></a>
+## 2   Another subtitle
+
+
+Some code\:
+```python
+def main(argv):
+    if argv[1] == 'help':
+        print('Help!')
+```
+> [!NOTE]
+> 
+> Some note\.
+> 
+> This note has two paragraphs\.
+
+<details>
+<summary><strong>ERROR/3</strong> (&lt;string&gt;, line 74)</summary>
+
+
+Unknown directive type \"unknown\-shit\"\.
+```
+.. unknown-shit::
+
+  Something.
+```
+
+</details>
+
+<a id="a-sub-sub-title"></a>
+### 2\.1   A sub\-sub\-title
+
+
+Some text\.\.\.
+> 
+> Some block quote\.
+> > 
+> > A nested block quote\.
+
+---
+
+
+Some unformatted code\:
+```
+foo bar!
+baz bam.
+```""",
+        set(),
+    ),
+    (
+        "table",
+        r""".. _tables:
+
+======
+Tables
+======
+
+Regular table:
+
++-----+-----+
+| Foo | Bar |
++=====+=====+
+| A   | B   |
++-----+-----+
+| C   | D   |
+|     | DD  |
+|     | DDD |
++-----+-----+
+
+A list table:
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Foo
+    - Bar
+  * - A
+    - B
+  * - C
+    - D
+
+      DD
+
+      DDD
+""",
+        "restructuredtext",
+        r"""# Tables
+
+<a id="tables"></a>
+
+Regular table\:
+
+A list table\:""",
+        {"table"},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "title, input, input_parser, output, unsupported_class_names",
+    RENDER_AS_MARKDOWN_AND_STRUCTURE_DATA,
+    ids=[e[0] for e in RENDER_AS_MARKDOWN_AND_STRUCTURE_DATA],
+)
+def test_render_markdown(title, input, input_parser, output, unsupported_class_names):
+    result = render_as_markdown(input, parser_name=input_parser)
+    assert result.output == output
+    assert result.unsupported_class_names == unsupported_class_names

--- a/tests/functional/test_rendering.py
+++ b/tests/functional/test_rendering.py
@@ -62,6 +62,8 @@ A list:
 
   This is still item 2.
 * Item 3.
+*
+* Item 5 after an empty item.
 
 An enumeration:
 
@@ -106,6 +108,8 @@ Some code:
 A sub-sub-title
 ~~~~~~~~~~~~~~~
 
+Something problematic: :pep:`1000000`
+
 Some text...
 
   Some block quote.
@@ -118,6 +122,11 @@ Some unformatted code::
 
     foo bar!
     baz bam.
+
+A sub-sub-title
+~~~~~~~~~~~~~~~
+
+The same sub-sub-title again.
 """,
         "restructuredtext",
         r"""# Main title
@@ -129,8 +138,10 @@ Some text\.
 - [1   This is a subtitle](\#this\-is\-a\-subtitle)
 - [2   Another subtitle](\#another\-subtitle)
   - [2\.1   A sub\-sub\-title](\#a\-sub\-sub\-title)
+  - [2\.2   A sub\-sub\-title](\#a\-sub\-sub\-title\-1)
 <a id="label"></a>
 <a id="label-2"></a>
+
 <a id="this-is-a-subtitle"></a>
 ## 1   This is a subtitle
 
@@ -148,6 +159,8 @@ A list\:
   
   This is still item 2\.
 - Item 3\.
+- \ 
+- Item 5 after an empty item\.
 
 An enumeration\:
 1. Entry 1
@@ -166,6 +179,7 @@ An enumeration\:
         ```
         ````
      1. Another entry
+
 <a id="another-subtitle"></a>
 ## 2   Another subtitle
 
@@ -181,8 +195,20 @@ def main(argv):
 > Some note\.
 > 
 > This note has two paragraphs\.
+
 <a id="a-sub-sub-title"></a>
 ### 2\.1   A sub\-sub\-title
+
+
+Something problematic\: <a href="#system-message-1"><span class="problematic">\:pep\:\`1000000\`</span></a>
+
+<details>
+<summary><strong>ERROR/3</strong> (&lt;string&gt;, line 77)</summary>
+
+
+PEP number must be a number from 0 to 9999\; \"1000000\" is invalid\.
+
+</details>
 
 
 Some text\.\.\.
@@ -198,7 +224,13 @@ Some unformatted code\:
 ```
 foo bar!
 baz bam.
-```""",
+```
+
+<a id="a-sub-sub-title-1"></a>
+### 2\.2   A sub\-sub\-title
+
+
+The same sub\-sub\-title again\.""",
         set(),
     ),
     (
@@ -234,6 +266,43 @@ Unknown directive type \"unknown\-shit\"\.
 ```
 
 </details>""",
+        set(),
+    ),
+    (
+        "image",
+        r"""Image:
+
+.. image:: image.png
+    :alt: An image
+
+Image w/o alt:
+
+.. image:: https://example.com/image.png
+
+Image w/o alt, with size:
+
+.. image:: https://example.com/image.png
+    :width: 100px
+    :height: 50px
+
+Image with size:
+
+.. image:: https://example.com/image.png
+    :alt: An image
+    :width: 150px
+""",
+        "restructuredtext",
+        r"""Image\:
+![An image](image\.png)
+
+Image w/o alt\:
+![](https\://example\.com/image\.png)
+
+Image w/o alt\, with size\:
+<img src="https://example.com/image.png" width="100px" height="50px">
+
+Image with size\:
+<img src="https://example.com/image.png" alt="An image" width="150px">""",
         set(),
     ),
     (

--- a/tests/functional/test_rendering.py
+++ b/tests/functional/test_rendering.py
@@ -103,12 +103,6 @@ Some code:
   
   This note has two paragraphs.
 
-.. Trigger a system message:
-
-.. unknown-shit::
-
-  Something.
-
 A sub-sub-title
 ~~~~~~~~~~~~~~~
 
@@ -187,20 +181,6 @@ def main(argv):
 > Some note\.
 > 
 > This note has two paragraphs\.
-
-<details>
-<summary><strong>ERROR/3</strong> (&lt;string&gt;, line 74)</summary>
-
-
-Unknown directive type \"unknown\-shit\"\.
-```
-.. unknown-shit::
-
-  Something.
-```
-
-</details>
-
 <a id="a-sub-sub-title"></a>
 ### 2\.1   A sub\-sub\-title
 
@@ -219,6 +199,41 @@ Some unformatted code\:
 foo bar!
 baz bam.
 ```""",
+        set(),
+    ),
+    (
+        "system-messages",
+        r"""
+==========
+Main title
+==========
+
+Some text.
+
+.. Trigger a system message:
+
+.. unknown-shit::
+
+  Something.
+""",
+        "restructuredtext",
+        r"""# Main title
+
+
+Some text\.
+
+<details>
+<summary><strong>ERROR/3</strong> (&lt;string&gt;, line 10)</summary>
+
+
+Unknown directive type \"unknown\-shit\"\.
+```
+.. unknown-shit::
+
+  Something.
+```
+
+</details>""",
         set(),
     ),
     (
@@ -279,5 +294,6 @@ A list table\:""",
 )
 def test_render_markdown(title, input, input_parser, output, unsupported_class_names):
     result = render_as_markdown(input, parser_name=input_parser)
+    print(get_document_structure(input, parser_name=input_parser).output)
     assert result.output == output
     assert result.unsupported_class_names == unsupported_class_names

--- a/tests/functional/test_rendering.py
+++ b/tests/functional/test_rendering.py
@@ -131,12 +131,13 @@ The same sub-sub-title again.
         "restructuredtext",
         r"""# Main title
 
-
 Some text\.
+
 ## Table of Contents
 
 - [1   This is a subtitle](\#this\-is\-a\-subtitle)
 - [2   Another subtitle](\#another\-subtitle)
+
   - [2\.1   A sub\-sub\-title](\#a\-sub\-sub\-title)
   - [2\.2   A sub\-sub\-title](\#a\-sub\-sub\-title\-1)
 <a id="label"></a>
@@ -144,7 +145,6 @@ Some text\.
 
 <a id="this-is-a-subtitle"></a>
 ## 1   This is a subtitle
-
 
 Some test with <code>code</code>\.
 Some <em>emphasis</em> and <strong>bold</strong> text\.
@@ -154,24 +154,29 @@ A [link](https\://ansible\.com/\))\.
 A [reference](\#label)\.
 
 A list\:
+
 - Item 1\.
 - Item 2\.
-  
+
   This is still item 2\.
 - Item 3\.
 - \ 
 - Item 5 after an empty item\.
 
 An enumeration\:
+
 1. Entry 1
-   
+
    More of Entry 1
 1. Entry 2
 1. Entry 3
    Second line of entry 3
+
    - Sublist
    - Another entry
+
      1. Subenum
+
         ````markdown
         Some codeblock:
         ```python
@@ -183,15 +188,14 @@ An enumeration\:
 <a id="another-subtitle"></a>
 ## 2   Another subtitle
 
-
 Some code\:
+
 ```python
 def main(argv):
     if argv[1] == 'help':
         print('Help!')
 ```
 > [!NOTE]
-> 
 > Some note\.
 > 
 > This note has two paragraphs\.
@@ -199,28 +203,25 @@ def main(argv):
 <a id="a-sub-sub-title"></a>
 ### 2\.1   A sub\-sub\-title
 
-
 Something problematic\: <a href="#system-message-1"><span class="problematic">\:pep\:\`1000000\`</span></a>
 
 <details>
 <summary><strong>ERROR/3</strong> (&lt;string&gt;, line 77)</summary>
 
-
 PEP number must be a number from 0 to 9999\; \"1000000\" is invalid\.
 
 </details>
 
-
 Some text\.\.\.
-> 
+
 > Some block quote\.
-> > 
+>
 > > A nested block quote\.
 
 ---
 
-
 Some unformatted code\:
+
 ```
 foo bar!
 baz bam.
@@ -228,7 +229,6 @@ baz bam.
 
 <a id="a-sub-sub-title-1"></a>
 ### 2\.2   A sub\-sub\-title
-
 
 The same sub\-sub\-title again\.""",
         set(),
@@ -251,14 +251,13 @@ Some text.
         "restructuredtext",
         r"""# Main title
 
-
 Some text\.
 
 <details>
 <summary><strong>ERROR/3</strong> (&lt;string&gt;, line 10)</summary>
 
-
 Unknown directive type \"unknown\-shit\"\.
+
 ```
 .. unknown-shit::
 
@@ -293,15 +292,19 @@ Image with size:
 """,
         "restructuredtext",
         r"""Image\:
+
 ![An image](image\.png)
 
 Image w/o alt\:
+
 ![](https\://example\.com/image\.png)
 
 Image w/o alt\, with size\:
+
 <img src="https://example.com/image.png" width="100px" height="50px">
 
 Image with size\:
+
 <img src="https://example.com/image.png" alt="An image" width="150px">""",
         set(),
     ),
@@ -322,6 +325,7 @@ Regular table:
 +-----+-----+
 | C   | D   |
 |     | DD  |
+|     |     |
 |     | DDD |
 +-----+-----+
 

--- a/tests/units/test_config.py
+++ b/tests/units/test_config.py
@@ -352,3 +352,11 @@ def test_collection_details(tmp_path):
     assert details.get_name() == "asdf"
     assert details.get_version() == "1.0.0"
     assert details.get_flatmap() is False
+
+
+def test_config_loading_bad_output_format(ansible_config_path):
+    ansible_config_path.write_text("output_formats: [foobar]")
+    paths = PathsConfig.detect()
+    collection_details = CollectionDetails(paths)
+    with pytest.raises(ChangelogError):
+        ChangelogConfig.load(paths, collection_details)


### PR DESCRIPTION
This is a project to render changelogs as MarkDown files next to ReStructuredText files (the current default).

This is necessary since GitHub screwed up their RST preview, which results in many collection changelogs to no longer render. This also affects the main Ansible changelogs.

Ref: https://github.com/orgs/community/discussions/86715
