### PR TITLE
Fix rendering of markdown in Automation Hub

### DIFF
--- a/changelogs/fragments/markdown-for-automationhub.yml
+++ b/changelogs/fragments/markdown-for-automationhub.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - The markdown generated did not render correctly in Ansible Automation Hub

--- a/src/antsibull_changelog/rendering/md_document.py
+++ b/src/antsibull_changelog/rendering/md_document.py
@@ -87,7 +87,7 @@ class MDTOCRenderer(BaseContent):
             f'{indent}- <a href="#{html_escape(entry.section.ref_id)}">'
             f"{md_escape(entry.section.title)}</a>"
         )
-        next_indent = f"{indent}  "
+        next_indent = f"{indent}    "
         for child in entry.children:
             self._append_toc_entry(lines, child, next_indent)
 
@@ -98,6 +98,7 @@ class MDTOCRenderer(BaseContent):
         ensure_newline_after_last_content(lines)
         if self.title:
             lines.append(f"**{md_escape(self.title)}**")
+            lines.append("")
         for entry in toc:
             self._append_toc_entry(lines, entry, "")
 

--- a/tests/functional/test_changelog_basic_collection.py
+++ b/tests/functional/test_changelog_basic_collection.py
@@ -119,8 +119,9 @@ This is the first proper release.
         r"""# Ansible Release Notes
 
 **Topics**
+
 - <a href="#v1-0-0">v1\.0\.0</a>
-  - <a href="#release-summary">Release Summary</a>
+    - <a href="#release-summary">Release Summary</a>
 
 <a id="v1-0-0"></a>
 ## v1\.0\.0
@@ -161,8 +162,9 @@ This is the first proper release\.
         r"""# Ansible Release Notes
 
 **Topics**
+
 - <a href="#v1-0-0">v1\.0\.0</a>
-  - <a href="#release-summary">Release Summary</a>
+    - <a href="#release-summary">Release Summary</a>
 
 <a id="v1-0-0"></a>
 ## v1\.0\.0
@@ -232,8 +234,9 @@ This is the first proper release.
         r"""# Ansible \"primetime\" Release Notes
 
 **Topics**
+
 - <a href="#v1-0-0">v1\.0\.0</a>
-  - <a href="#release-summary">Release Summary</a>
+    - <a href="#release-summary">Release Summary</a>
 
 <a id="v1-0-0"></a>
 ## v1\.0\.0
@@ -302,9 +305,10 @@ This is the first proper release.
         r"""# Ansible Release Notes
 
 **Topics**
+
 - <a href="#v1-1-0">v1\.1\.0</a>
 - <a href="#v1-0-0">v1\.0\.0</a>
-  - <a href="#release-summary">Release Summary</a>
+    - <a href="#release-summary">Release Summary</a>
 
 <a id="v1-1-0"></a>
 ## v1\.1\.0


### PR DESCRIPTION
When generating the changelog for an Ansible Collection in markdown, it will not render properly when the collection is uploaded to Automation Hub and viewed in the web UI.

This is fixed by adding a blank line after the TOC topic, and using 4 spaces instead of 2 for indentation of nested lists.