### PR TITLE
fix: make yaml output pass `ansible-lint`

### DIFF
--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -36,3 +36,4 @@ title: Ansible Changelog Tool
 output_formats:
   - rst
   - md
+changelog_nice_yaml: false

--- a/changelogs/fragments/160-changelog-nice-yaml.yml
+++ b/changelogs/fragments/160-changelog-nice-yaml.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - |
+    Adds yaml boundary marker --- to the header of the file.
+    Increases indentation level on list items.
+    Makes changelog.yaml pass ansible-lint

--- a/changelogs/fragments/160-changelog-nice-yaml.yml
+++ b/changelogs/fragments/160-changelog-nice-yaml.yml
@@ -1,6 +1,9 @@
 ---
 minor_changes:
   - |
-    Adds yaml boundary marker --- to the header of the file.
-    Increases indentation level on list items.
-    Makes changelog.yaml pass ansible-lint
+    There is now an option ``changelog_nice_yaml`` to prepend the YAML document start
+    marker ``---`` to the header of the ``changelogs/changelog.yaml`` file, and to increases
+    indentation level on list items. This makes the file pass ansible-lint
+    (https://github.com/ansible-community/antsibull-changelog/issues/91,
+    https://github.com/ansible-community/antsibull-changelog/issues/152,
+    https://github.com/ansible-community/antsibull-changelog/pull/160).

--- a/docs/changelog-configuration.md
+++ b/docs/changelog-configuration.md
@@ -259,8 +259,8 @@ are `rst` for ReStructuredText and `md` for MarkDown.
 
 The default is `false`.
 
-OWhen set to `true` the chanelog.yaml format will be written with nice yaml
-format that's compatible with `ansible-lint`default rules
+When set to `true` the changelog.yaml format will be written with nice yaml
+format that's compatible with `ansible-lint`default rules.
 
 ## Deprecated options
 

--- a/docs/changelog-configuration.md
+++ b/docs/changelog-configuration.md
@@ -247,6 +247,13 @@ The default is `["rst"]`.
 A list of output formats to write the changelog as. Supported formats
 are `rst` for ReStructuredText and `md` for MarkDown.
 
+### `changelog_nice_yaml`(boolean)`
+
+The default is `false`.
+
+OWhen set to `true` the chanelog.yaml format will be written with nice yaml
+format that's compatible with `ansible-lint`default rules
+
 ## Deprecated options
 
 ### `new_plugins_after_name` (string)

--- a/docs/changelog-configuration.md
+++ b/docs/changelog-configuration.md
@@ -255,12 +255,16 @@ The default is `["rst"]`.
 A list of output formats to write the changelog as. Supported formats
 are `rst` for ReStructuredText and `md` for MarkDown.
 
-### `changelog_nice_yaml`(boolean)`
+### `changelog_nice_yaml` (boolean)
 
 The default is `false`.
 
-When set to `true` the changelog.yaml format will be written with nice yaml
-format that's compatible with `ansible-lint`default rules.
+When set to `true`, the `changelogs/changelog.yaml` file will be written with a slightly different
+YAML encoding that is compatible with ansible-lint's default rules.
+
+!!! note
+    The exact format used might be adjusted in the future if new releases of ansible-lint
+    adjust their yamllint configuration.
 
 ## Deprecated options
 

--- a/docs/changelog-configuration.md
+++ b/docs/changelog-configuration.md
@@ -92,6 +92,17 @@ except when using the changelog generator for Ansible 2.9 or earlier.
 Note that support for `classic` is **DEPRECATED** and will be removed in
 a future release. The field will from then on be required.
 
+### `changelog_nice_yaml` (boolean)
+
+The default is `false`.
+
+When set to `true`, the `changelogs/changelog.yaml` file will be written with a slightly different
+YAML encoding that is compatible with ansible-lint's default rules.
+
+!!! note
+    The exact format used might be adjusted in the future if new releases of ansible-lint
+    adjust their yamllint configuration.
+
 ### `flatmap` (optional boolean)
 
 The default value is `null`.
@@ -254,17 +265,6 @@ The default is `["rst"]`.
 
 A list of output formats to write the changelog as. Supported formats
 are `rst` for ReStructuredText and `md` for MarkDown.
-
-### `changelog_nice_yaml` (boolean)
-
-The default is `false`.
-
-When set to `true`, the `changelogs/changelog.yaml` file will be written with a slightly different
-YAML encoding that is compatible with ansible-lint's default rules.
-
-!!! note
-    The exact format used might be adjusted in the future if new releases of ansible-lint
-    adjust their yamllint configuration.
 
 ## Deprecated options
 

--- a/src/antsibull_changelog/changes.py
+++ b/src/antsibull_changelog/changes.py
@@ -156,7 +156,7 @@ class ChangesBase(metaclass=abc.ABCMeta):
         """
         self.sort()
         self.data["ancestor"] = self.ancestor
-        store_yaml(self.path, self.data)
+        store_yaml(self.path, self.data, self.config.changelog_nice_yaml)
 
     def add_release(
         self,

--- a/src/antsibull_changelog/config.py
+++ b/src/antsibull_changelog/config.py
@@ -378,6 +378,7 @@ class ChangelogConfig:
     is_other_project: bool
     sections: Mapping[str, str]
     output_formats: set[TextFormat]
+    changelog_nice_yaml: bool
 
     def __init__(
         self,
@@ -465,6 +466,8 @@ class ChangelogConfig:
                     f"Found unknown extension in output_formats: {exc}"
                 ) from exc
 
+        self.changelog_nice_yaml = self.config.get("changelog_nice_yaml", False)
+
         self._validate_config(ignore_is_other_project)
 
     def _validate_config(self, ignore_is_other_project: bool) -> None:
@@ -514,6 +517,7 @@ class ChangelogConfig:
             "trivial_section_name": self.trivial_section_name,
             "ignore_other_fragment_extensions": self.ignore_other_fragment_extensions,
             "sanitize_changelog": self.sanitize_changelog,
+            "changelog_nice_yaml": self.changelog_nice_yaml,
         }
         if not self.is_collection:
             if self.use_semantic_versioning:
@@ -592,6 +596,7 @@ class ChangelogConfig:
             "use_fqcn": True,
             "ignore_other_fragment_extensions": True,
             "sanitize_changelog": True,
+            "changelog_nice_yaml": False,
         }
         if title is not None:
             config["title"] = title

--- a/src/antsibull_changelog/config.py
+++ b/src/antsibull_changelog/config.py
@@ -468,7 +468,7 @@ class ChangelogConfig:
                 ) from exc
 
         self.add_plugin_period = self.config.get("add_plugin_period", False)
-  
+
         self.changelog_nice_yaml = self.config.get("changelog_nice_yaml", False)
 
         self._validate_config(ignore_is_other_project)
@@ -520,9 +520,8 @@ class ChangelogConfig:
             "trivial_section_name": self.trivial_section_name,
             "ignore_other_fragment_extensions": self.ignore_other_fragment_extensions,
             "sanitize_changelog": self.sanitize_changelog,
-            "add_plugin_period": self.add_plugin_period,          
+            "add_plugin_period": self.add_plugin_period,
             "changelog_nice_yaml": self.changelog_nice_yaml,
-
         }
         if not self.is_collection:
             if self.use_semantic_versioning:
@@ -603,7 +602,6 @@ class ChangelogConfig:
             "sanitize_changelog": True,
             "add_plugin_period": True,
             "changelog_nice_yaml": False,
-
         }
         if title is not None:
             config["title"] = title

--- a/src/antsibull_changelog/yaml.py
+++ b/src/antsibull_changelog/yaml.py
@@ -40,4 +40,10 @@ def store_yaml(path: str, content: Any) -> None:
     with open(path, "w", encoding="utf-8") as stream:
         dumper = _SafeDumper
         dumper.ignore_aliases = lambda *args: True
-        yaml.dump(content, stream, default_flow_style=False, Dumper=dumper)
+        yaml.dump(
+            content,
+            stream,
+            default_flow_style=False,
+            Dumper=dumper,
+            explicit_start=True
+        )

--- a/src/antsibull_changelog/yaml.py
+++ b/src/antsibull_changelog/yaml.py
@@ -14,15 +14,19 @@ from typing import Any
 
 import yaml
 
+
 _SafeLoader: Any
+_SafeDumper: Any
 try:
     # use C version if possible for speedup
+    from yaml import CSafeDumper as _SafeDumper
     from yaml import CSafeLoader as _SafeLoader
 except ImportError:
+    from yaml import SafeDumper as _SafeDumper
     from yaml import SafeLoader as _SafeLoader
 
 
-class _SafeDumper(yaml.SafeDumper):
+class _IndentedDumper(yaml.SafeDumper):
     """
     Extend YAML dumper to increase indent of list items.
     """
@@ -38,7 +42,7 @@ def load_yaml(path: str) -> Any:
         return yaml.load(stream, Loader=_SafeLoader)
 
 
-def store_yaml(path: str, content: Any) -> None:
+def store_yaml(path: str, content: Any, nice: bool) -> None:
     """
     Store ``content`` as YAML file under ``path``.
     """
@@ -47,6 +51,6 @@ def store_yaml(path: str, content: Any) -> None:
             content,
             stream,
             default_flow_style=False,
-            Dumper=_SafeDumper,
-            explicit_start=True
+            Dumper=_IndentedDumper if nice else _SafeDumper,
+            explicit_start=nice
         )

--- a/src/antsibull_changelog/yaml.py
+++ b/src/antsibull_changelog/yaml.py
@@ -14,7 +14,6 @@ from typing import Any
 
 import yaml
 
-
 _SafeLoader: Any
 _SafeDumper: Any
 try:
@@ -30,6 +29,7 @@ class _IndentedDumper(yaml.SafeDumper):
     """
     Extend YAML dumper to increase indent of list items.
     """
+
     def increase_indent(self, flow=False, indentless=False):
         return super().increase_indent(flow, False)
 
@@ -52,5 +52,5 @@ def store_yaml(path: str, content: Any, nice: bool = False) -> None:
             stream,
             default_flow_style=False,
             Dumper=_IndentedDumper if nice else _SafeDumper,
-            explicit_start=nice
+            explicit_start=nice,
         )

--- a/src/antsibull_changelog/yaml.py
+++ b/src/antsibull_changelog/yaml.py
@@ -15,14 +15,19 @@ from typing import Any
 import yaml
 
 _SafeLoader: Any
-_SafeDumper: Any
 try:
     # use C version if possible for speedup
-    from yaml import CSafeDumper as _SafeDumper
     from yaml import CSafeLoader as _SafeLoader
 except ImportError:
-    from yaml import SafeDumper as _SafeDumper
     from yaml import SafeLoader as _SafeLoader
+
+
+class _SafeDumper(yaml.SafeDumper):
+    """
+    Extend YAML dumper to increase indent of list items.
+    """
+    def increase_indent(self, flow=False, indentless=False):
+        return super().increase_indent(flow, False)
 
 
 def load_yaml(path: str) -> Any:
@@ -38,12 +43,10 @@ def store_yaml(path: str, content: Any) -> None:
     Store ``content`` as YAML file under ``path``.
     """
     with open(path, "w", encoding="utf-8") as stream:
-        dumper = _SafeDumper
-        dumper.ignore_aliases = lambda *args: True
         yaml.dump(
             content,
             stream,
             default_flow_style=False,
-            Dumper=dumper,
+            Dumper=_SafeDumper,
             explicit_start=True
         )

--- a/src/antsibull_changelog/yaml.py
+++ b/src/antsibull_changelog/yaml.py
@@ -42,7 +42,7 @@ def load_yaml(path: str) -> Any:
         return yaml.load(stream, Loader=_SafeLoader)
 
 
-def store_yaml(path: str, content: Any, nice: bool) -> None:
+def store_yaml(path: str, content: Any, nice: bool = False) -> None:
     """
     Store ``content`` as YAML file under ``path``.
     """


### PR DESCRIPTION
* Adds yaml boundary marker `---` to the header of the file.
* Increases indentation level on list items.

fixes: #91 
fixes: #152