### PR TITLE
Remove Python version check

### DIFF
--- a/changelogs/fragments/167-python.yml
+++ b/changelogs/fragments/167-python.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Adjust the Python version check in ``main()`` to test for Python 3.9 instead of 3.6, which is the minimum required Python version since version 0.18.0 (https://github.com/ansible-community/antsibull-changelog/pull/167)."

--- a/changelogs/fragments/167-python.yml
+++ b/changelogs/fragments/167-python.yml
@@ -1,2 +1,6 @@
 bugfixes:
-  - "Adjust the Python version check in ``main()`` to test for Python 3.9 instead of 3.6, which is the minimum required Python version since version 0.18.0 (https://github.com/ansible-community/antsibull-changelog/pull/167)."
+  - "Remove Python version check that was checking for Python >= 3.6 (instead of >= 3.9).
+     This check is not really necessary since ``pyproject.toml`` declares ``requires-python``,
+     and old enough Python versions where pip does not know about ``requires-python``
+     will not load antsibull-changelog due to syntax errors anyway
+     (https://github.com/ansible-community/antsibull-changelog/pull/167)."

--- a/src/antsibull_changelog/cli.py
+++ b/src/antsibull_changelog/cli.py
@@ -869,8 +869,8 @@ def main() -> int:
     See constants.py for the return codes.
     """
 
-    if sys.version_info < (3, 6):
-        print("Needs Python 3.6 or later")
+    if sys.version_info < (3, 9):
+        print("Needs Python 3.9 or later")
         return C.RC_OLD_PYTHON
 
     return run(sys.argv)

--- a/src/antsibull_changelog/cli.py
+++ b/src/antsibull_changelog/cli.py
@@ -869,8 +869,4 @@ def main() -> int:
     See constants.py for the return codes.
     """
 
-    if sys.version_info < (3, 9):
-        print("Needs Python 3.9 or later")
-        return C.RC_OLD_PYTHON
-
     return run(sys.argv)

--- a/src/antsibull_changelog/constants.py
+++ b/src/antsibull_changelog/constants.py
@@ -12,5 +12,4 @@ RC_SUCCESS = 0  # Success
 RC_UNHANDLED_ERROR = 1  # Unhandled error.  See the Traceback for more information.
 RC_BAD_CLI_ARG = 2  # There was a problem with the command line arguments.
 RC_INVALID_FRAGMENT = 3  # Found invalid changelog fragments.
-RC_OLD_PYTHON = 4  # Needs to be run on a newer version of Python.
 RC_COMMAND_FAILED = 5  # Problem occurred which prevented the execution of the command.


### PR DESCRIPTION
It was checking for Python 3.6, for which we dropped support quite some time ago (we're requiring Python 3.9+ since 2022-12-17).