### PR TITLE
Docsite: add Community guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ A changelog generator used by ansible-core and Ansible collections.
 
 antsibull-changelog is covered by the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
 
+## Community
+
+Need help or want to discuss the project? See our [Community guide](https://ansible.readthedocs.io/projects/antsibull-changelog/community/) to learn how to join the conversation!
+
 ## Installation
 
 It can be installed with pip:

--- a/docs/community.md
+++ b/docs/community.md
@@ -16,4 +16,8 @@ Join the [Ansible Forum](https://forum.ansible.com) as a single starting point a
 * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
 * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events. The [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn), which is used to announce releases and important changes, can also be found here.
 
-For more information on the forum navigation, see [Navigating the Ansible forum](https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39) post.
+For more information on the forum navigation, see the [Navigating the Ansible forum](https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39) post.
+
+## Matrix
+
+For real-time interactions, join the [#antsibull:ansible.com](https://matrix.to/#/#antsibull:ansible.com) Matrix channel. See the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat) for more information.

--- a/docs/community.md
+++ b/docs/community.md
@@ -6,7 +6,6 @@ We welcome your feedback, questions and ideas. Here's how to reach the community
 
 Join the [Ansible Forum](https://forum.ansible.com) as a single starting point and our default communication platform for questions and help, development discussions, events, and much more. [Register](https://forum.ansible.com/signup?) to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
 
-* [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example `antsibull`.
 * [Posts tagged with 'antsibull'](https://forum.ansible.com/tag/antsibull): subscribe to participate in project-related conversations.
 * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
 * [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events. The [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn), which is used to announce releases and important changes, can also be found here.

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (c) Ansible Project
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
 # Community
 
 We welcome your feedback, questions and ideas. Here's how to reach the community.

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,14 @@
+# Community
+
+We welcome your feedback, questions and ideas. Here's how to reach the community.
+
+## Forum
+
+Join the [Ansible Forum](https://forum.ansible.com) as a single starting point and our default communication platform for questions and help, development discussions, events, and much more. [Register](https://forum.ansible.com/signup?) to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
+
+* [Get Help](https://forum.ansible.com/c/help/6): get help or help others. Please add appropriate tags if you start new discussions, for example `antsibull`.
+* [Posts tagged with 'antsibull'](https://forum.ansible.com/tag/antsibull): subscribe to participate in project-related conversations.
+* [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.
+* [News & Announcements](https://forum.ansible.com/c/news/5): track project-wide announcements including social events. The [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn), which is used to announce releases and important changes, can also be found here.
+
+For more information on the forum navigation, see [Navigating the Ansible forum](https://forum.ansible.com/t/navigating-the-ansible-forum-tags-categories-and-concepts/39) post.

--- a/docs/community.md
+++ b/docs/community.md
@@ -20,4 +20,4 @@ For more information on the forum navigation, see the [Navigating the Ansible fo
 
 ## Matrix
 
-For real-time interactions, join the [#antsibull:ansible.com](https://matrix.to/#/#antsibull:ansible.com) Matrix channel. See the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat) for more information.
+For real-time interactions, join the [#antsibull:ansible.com Matrix room](https://matrix.to/#/#antsibull:ansible.com). See the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html#real-time-chat) for more information on Matrix.

--- a/docs/community.md
+++ b/docs/community.md
@@ -10,7 +10,7 @@ We welcome your feedback, questions and ideas. Here's how to reach the community
 
 ## Forum
 
-Join the [Ansible Forum](https://forum.ansible.com) as a single starting point and our default communication platform for questions and help, development discussions, events, and much more. [Register](https://forum.ansible.com/signup?) to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
+Join the [Ansible Forum](https://forum.ansible.com) as a single starting point and our default communication platform for questions and help, development discussions, events, and much more. [Register on the Forum](https://forum.ansible.com/signup?) to join the community. Search by categories and tags to find interesting topics or start a new one; subscribe only to topics you need!
 
 * [Posts tagged with 'antsibull'](https://forum.ansible.com/tag/antsibull): subscribe to participate in project-related conversations.
 * [Social Spaces](https://forum.ansible.com/c/chat/4): gather and interact with fellow enthusiasts.

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
 [![Nox badge](https://github.com/ansible-community/antsibull-changelog/workflows/nox/badge.svg?event=push&branch=main)](https://github.com/ansible-community/antsibull-changelog/actions?query=workflow%3A%22nox%22+branch%3Amain)
 [![Codecov badge](https://img.shields.io/codecov/c/github/ansible-community/antsibull-changelog)](https://codecov.io/gh/ansible-community/antsibull-changelog)
 
+> Need help or want to discuss the project? See our [Community guide](https://ansible.readthedocs.io/projects/antsibull-changelog/community/) to learn how to join the conversation!
+
 A changelog generator used by ansible-core and Ansible collections.
 
 - Using the [`antsibull-changelog` CLI tool for collections](changelogs.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,8 @@ antsibull-changelog is covered by the [Ansible Code of Conduct](https://docs.ans
 To see how antsibull-changelog changes, please look at the
 [antsibull-changelog changelog](https://github.com/ansible-community/antsibull-changelog/blob/main/CHANGELOG.md).
 
-> Need help or want to discuss the project? See our [Community guide](community.md) to learn how to join the conversation!
+!!! note
+    Need help or want to discuss the project? See our [Community guide](community.md) to learn how to join the conversation!
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 [![Nox badge](https://github.com/ansible-community/antsibull-changelog/workflows/nox/badge.svg?event=push&branch=main)](https://github.com/ansible-community/antsibull-changelog/actions?query=workflow%3A%22nox%22+branch%3Amain)
 [![Codecov badge](https://img.shields.io/codecov/c/github/ansible-community/antsibull-changelog)](https://codecov.io/gh/ansible-community/antsibull-changelog)
 
-> Need help or want to discuss the project? See our [Community guide](https://ansible.readthedocs.io/projects/antsibull-changelog/community/) to learn how to join the conversation!
+> Need help or want to discuss the project? See our [Community guide](community.md) to learn how to join the conversation!
 
 A changelog generator used by ansible-core and Ansible collections.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 [![Nox badge](https://github.com/ansible-community/antsibull-changelog/workflows/nox/badge.svg?event=push&branch=main)](https://github.com/ansible-community/antsibull-changelog/actions?query=workflow%3A%22nox%22+branch%3Amain)
 [![Codecov badge](https://img.shields.io/codecov/c/github/ansible-community/antsibull-changelog)](https://codecov.io/gh/ansible-community/antsibull-changelog)
 
-> Need help or want to discuss the project? See our [Community guide](community.md) to learn how to join the conversation!
-
 A changelog generator used by ansible-core and Ansible collections.
 
 - Using the [`antsibull-changelog` CLI tool for collections](changelogs.md).
@@ -23,6 +21,8 @@ antsibull-changelog is covered by the [Ansible Code of Conduct](https://docs.ans
 
 To see how antsibull-changelog changes, please look at the
 [antsibull-changelog changelog](https://github.com/ansible-community/antsibull-changelog/blob/main/CHANGELOG.md).
+
+> Need help or want to discuss the project? See our [Community guide](community.md) to learn how to join the conversation!
 
 ## Installation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,4 +34,5 @@ nav:
   - other-projects.md
   - changelog-configuration.md
   - changelog.yaml-format.md
+  - community.md
   - antsibull-changelog Release Notes: changelog.md


### PR DESCRIPTION
Dear maintainers,
As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR adds the communication section template defined by the community to the README and the docsite. Similar PRs are now being raised across all the Ansible ecosystem projects.

Thank you