### PR TITLE
Add --strict parameter to lint-changelog-yaml subcommand

### DIFF
--- a/changelogs/fragments/182-strict-linting.yml
+++ b/changelogs/fragments/182-strict-linting.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Add ``--strict`` parameter to the ``lint-changelog-yaml`` subcommand to also check for extra fields that should not be there (https://github.com/ansible-community/antsibull-changelog/pull/182)."

--- a/docs/changelog.yaml-format.md
+++ b/docs/changelog.yaml-format.md
@@ -21,6 +21,8 @@ You can use the `antsibull-changelog lint-changelog-yaml` tool included in the [
 
 The tool does not output anything and exits with exit code 0 in case the file is OK, and outputs errors and exits with exit code 3 in case an error was found. Other exit codes indicate problems with the command line or during the execution of the linter.
 
+To avoid extra data in `changelog.yaml` that should not be in there, add the `--strict` option. This can be useful to avoid typos, for example if you wrote `change:` instead of `changes:`, or forgot `changes:` alltogether.
+
 
 ## changelog.yaml
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -125,6 +125,14 @@ def integration(session: nox.Session):
         "changelogs/changelog.yaml",
     )
 
+    # Lint own changelogs/changelog.yaml in strict mode
+    cov_run(
+        "lint-changelog-yaml",
+        "--no-semantic-versioning",
+        "--strict",
+        "changelogs/changelog.yaml",
+    )
+
     # Lint community.general's changelogs/changelog.yaml
     cg_destination = tmp / "community.general"
     if not cg_destination.exists():
@@ -133,13 +141,18 @@ def integration(session: nox.Session):
                 "git",
                 "clone",
                 "https://github.com/ansible-collections/community.general",
-                "--branch=stable-4",
+                "--branch=stable-9",
                 "--depth=1",
                 external=True,
             )
     cov_run(
         "lint-changelog-yaml",
         str(cg_destination / "changelogs" / "changelog.yaml"),
+    )
+    cov_run(
+        "lint-changelog-yaml",
+        str(cg_destination / "changelogs" / "changelog.yaml"),
+        "--strict",
     )
 
     combined = map(str, tmp.glob(".coverage.*"))

--- a/src/antsibull_changelog/cli.py
+++ b/src/antsibull_changelog/cli.py
@@ -180,13 +180,19 @@ def create_argparser(program_name: str) -> argparse.ArgumentParser:
     lint_changelog_yaml_parser = subparsers.add_parser(
         "lint-changelog-yaml",
         parents=[common],
-        help="check syntax of" " changelogs/changelog.yaml file",
+        help="check syntax of changelogs/changelog.yaml file",
     )
     lint_changelog_yaml_parser.set_defaults(func=command_lint_changelog_yaml)
     lint_changelog_yaml_parser.add_argument(
         "changelog_yaml_path",
         metavar="/path/to/changelog.yaml",
         help="path to changelogs/changelog.yaml",
+    )
+    lint_changelog_yaml_parser.add_argument(
+        "--strict",
+        type=parse_boolean_arg,
+        help="do more strict checking, for example complain about extra"
+        " entries that are not mentioned in the changelog.yaml specification",
     )
 
     lint_changelog_yaml_parser.add_argument(
@@ -834,7 +840,9 @@ def command_lint_changelog_yaml(args: Any) -> int:
     :arg args: Parsed arguments
     """
     errors = lint_changelog_yaml(
-        args.changelog_yaml_path, no_semantic_versioning=args.no_semantic_versioning
+        args.changelog_yaml_path,
+        no_semantic_versioning=args.no_semantic_versioning,
+        strict=args.strict,
     )
 
     messages = sorted(

--- a/tests/functional/bad/ansible-base-1.json
+++ b/tests/functional/bad/ansible-base-1.json
@@ -1,5 +1,8 @@
 {
     "errors": [
         [0, 0, "Invalid ancestor version: error while parse version '2.9.0b1': Invalid version string: '2.9.0b1'"]
+    ],
+    "errors_strict": [
+        [0, 0, "Invalid ancestor version: error while parse version '2.9.0b1': Invalid version string: '2.9.0b1'"]
     ]
 }

--- a/tests/functional/bad/felixfontein.hosttech_dns-1.json
+++ b/tests/functional/bad/felixfontein.hosttech_dns-1.json
@@ -2,5 +2,9 @@
     "errors": [
         [0, 0, "'releases' -> '1.0.0' -> 'modules' -> 0 -> 'name' must not be a FQCN"],
         [0, 0, "'releases' -> '1.0.0' -> 'modules' -> 1 -> 'name' must not be a FQCN"]
+    ],
+    "errors_strict": [
+        [0, 0, "'releases' -> '1.0.0' -> 'modules' -> 0 -> 'name' must not be a FQCN"],
+        [0, 0, "'releases' -> '1.0.0' -> 'modules' -> 1 -> 'name' must not be a FQCN"]
     ]
 }

--- a/tests/functional/bad/random-1.json
+++ b/tests/functional/bad/random-1.json
@@ -24,5 +24,31 @@
         [0, 0, "Invalid release version: error while parse version 2.0: Expecting string"],
         [0, 0, "'releases' -> 2.0 is expected to be <class 'dict'>, but got \\['lists', 'are not allowed'\\]"],
         [0, 0, "'releases' -> '3.0.0' is expected to be <class 'dict'>, but got 42"]
+    ],
+    "errors_strict": [
+        [0, 0, "Invalid ancestor version: error while parse version \\['test'\\]: Expecting string"],
+        [0, 0, "'releases' -> '1.0.0' -> 'release_date' must be a ISO date \\(YYYY-MM-DD\\)"],
+        [0, 0, "'releases' -> '1.0.0' -> 'changes': invalid section: invalid_category"],
+        [0, 0, "'releases' -> '1.0.0' -> 'changes': section \"invalid_category\" list items must be type str not int"],
+        [0, 0, "'releases' -> '1.0.0' -> 'changes': section \"minor_changes\" must be type list not dict"],
+        [0, 0, "'releases' -> '1.0.0' -> 'changes': section \"major_changes\" must be type list not int"],
+        [0, 0, "'releases' -> '1.0.0' -> 'modules' -> 0 -> 'name' must not be a FQCN"],
+        [0, 0, "'releases' -> '1.0.0' -> 'modules' -> 1 -> 'description' is expected to be <class 'str'>, but got None"],
+        [0, 0, "'releases' -> '1.0.0' -> 'modules' -> 1 -> 'namespace' must not contain spaces or slashes"],
+        [0, 0, "'releases' -> '1.0.0' -> 'modules' -> 2 -> 'namespace' must not contain spaces or slashes"],
+        [0, 0, "'releases' -> '1.0.0' -> 'modules' -> 3 -> 'namespace' must not contain spaces or slashes"],
+        [0, 0, "'releases' -> '1.0.0' -> 'modules' -> 4 -> 'namespace' is expected to be <class 'str'>, but got None"],
+        [0, 0, "'releases' -> '1.0.0' -> 'modules' -> 5 -> 'namespace' is expected to be <class 'str'>, but got None"],
+        [0, 0, "'releases' -> '1.0.0' -> 'plugins' -> 'lookup' -> 0 -> 'description' is expected to be <class 'str'>, but got 123"],
+        [0, 0, "'releases' -> '1.0.0' -> 'plugins' -> 'lookup' -> 0 -> 'namespace' must be null"],
+        [0, 0, "Unknown plugin type 'woo' in 'releases' -> '1.0.0' -> 'plugins'"],
+        [0, 0, "Unknown plugin type 'screwed' in 'releases' -> '1.0.0' -> 'plugins'"],
+        [0, 0, "'releases' -> '1.0.0' -> 'plugins' -> 'screwed' is expected to be <class 'list'>, but got 321"],
+        [0, 0, "'releases' -> '1.0.0' -> 'fragments' is expected to be null or <class 'list'>, but got {'files': 123}"],
+        [0, 0, "'releases' -> '1.1.0' -> 'release_date' is expected to be <class 'str'>, but got 12345"],
+        [0, 0, "'releases' -> '1.1.0' -> 'changes': section \"release_summary\" must be type str not int"],
+        [0, 0, "Invalid release version: error while parse version 2.0: Expecting string"],
+        [0, 0, "'releases' -> 2.0 is expected to be <class 'dict'>, but got \\['lists', 'are not allowed'\\]"],
+        [0, 0, "'releases' -> '3.0.0' is expected to be <class 'dict'>, but got 42"]
     ]
 }

--- a/tests/functional/bad/random-2.json
+++ b/tests/functional/bad/random-2.json
@@ -1,5 +1,8 @@
 {
     "errors": [
         [0, 0, "error while parsing YAML: .*in \"input.yaml\", line 7, column 1"]
+    ],
+    "errors_strict": [
+        [0, 0, "error while parsing YAML: .*in \"input.yaml\", line 7, column 1"]
     ]
 }

--- a/tests/functional/bad/random-3.json
+++ b/tests/functional/bad/random-3.json
@@ -1,5 +1,8 @@
 {
     "errors": [
         [0, 0, "'releases' is expected to be <class 'dict'>, but got \\[\\]"]
+    ],
+    "errors_strict": [
+        [0, 0, "'releases' is expected to be <class 'dict'>, but got \\[\\]"]
     ]
 }

--- a/tests/functional/bad/random-4.json
+++ b/tests/functional/bad/random-4.json
@@ -8,5 +8,20 @@
         [0, 0, "'releases' -> '1.0.0' -> 'plugins' -> 'callback' -> 1 -> 'description' is expected to be <class 'str'>, but got 234"],
         [0, 0, "'releases' -> '1.0.0' -> 'plugins' -> 'callback' -> 1 -> 'namespace' must be null"],
         [0, 0, "Unknown object type 'chair' in 'releases' -> '1.0.0' -> 'objects'"]
+    ],
+    "errors_strict": [
+        [0, 0, "release version '1.0.0' must come after ancestor version '1.0.0'"],
+        [0, 0, "'releases' -> '1.0.0' -> 'plugins' is expected to be <class 'str'>, but got 23"],
+        [0, 0, "Unknown plugin type 'foo' in 'releases' -> '1.0.0' -> 'plugins'"],
+        [0, 0, "'releases' -> '1.0.0' -> 'plugins' -> 'callback' -> 0 is expected to be <class 'dict'>, but got 42"],
+        [0, 0, "'releases' -> '1.0.0' -> 'plugins' -> 'callback' -> 1 -> 'name' is expected to be <class 'str'>, but got 123"],
+        [0, 0, "'releases' -> '1.0.0' -> 'plugins' -> 'callback' -> 1 -> 'description' is expected to be <class 'str'>, but got 234"],
+        [0, 0, "'releases' -> '1.0.0' -> 'plugins' -> 'callback' -> 1 -> 'namespace' must be null"],
+        [0, 0, "'releases' -> '1.0.0' -> 'plugins' -> 'callback' -> 2 -> 'extra_callback': extra key not allowed"],
+        [0, 0, "Unknown object type 'chair' in 'releases' -> '1.0.0' -> 'objects'"],
+        [0, 0, "'releases' -> '1.0.0' -> 'objects' -> 'chair' -> 0 -> 'extra_chair': extra key not allowed"],
+        [0, 0, "'releases' -> '1.0.0' -> 'objects' -> 'role' -> 0 -> 'extra_role': extra key not allowed"],
+        [0, 0, "'releases' -> '1.0.0' -> 'extra_release': extra key not allowed"],
+        [0, 0, "'extra_global': extra key not allowed"]
     ]
 }

--- a/tests/functional/bad/random-4.yaml
+++ b/tests/functional/bad/random-4.yaml
@@ -7,6 +7,7 @@ ancestor: 1.0.0
 releases:
   1.0.0:
     release_date: '2020-01-01'
+    extra_release: shouldn't be there
     plugins:
       23: []
       foo: []
@@ -17,12 +18,16 @@ releases:
           namespace: 345
         - name: foo
           description: bar
+          extra_callback: shouldn't be there
     objects:
       chair:
         - name: hello
           description: world
           namespace: null
+          extra_chair: shouldn't be there
       role:
         - name: my_role
           description: This is my role
           namespace: null
+          extra_role: shouldn't be there
+extra_global: shouldn't be there


### PR DESCRIPTION
The extra check makes sure that nothing's there that shouldn't be in changelogs/changelog.yaml.