### PR TITLE
Switch to pydantic for config parsing and validation

### DIFF
--- a/changelogs/fragments/193-config.yml
+++ b/changelogs/fragments/193-config.yml
@@ -1,0 +1,10 @@
+minor_changes:
+  - "Antsibull-changelog now uses Pydantic to parse and validate the config.
+     This means that validation is more strict than before and might reject configs that were incorrect, but still got accepted somehow
+     (https://github.com/ansible-community/antsibull-changelog/pull/193)."
+  - "Antsibull-changelog now depends on Pydantic 2 (https://github.com/ansible-community/antsibull-changelog/pull/193)."
+breaking_changes:
+  - "When using antsibull-changelog as a library, ``ChangelogConfig``'s constructor should no longer be called directly.
+     Instead, use the class method ``ChangelogConfig.parse()``, which has the same signature than the previous constructor,
+     except that ``ignore_is_other_project`` now must be a keyword parameter
+     (https://github.com/ansible-community/antsibull-changelog/pull/193)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "rstcheck >= 3.0.0, < 7.0.0",
     "semantic_version",
     "antsibull-docutils >= 1.0.0, < 2.0.0",
+    "pydantic ~= 2.0",
 ]
 
 [project.urls]

--- a/src/antsibull_changelog/cli.py
+++ b/src/antsibull_changelog/cli.py
@@ -341,7 +341,7 @@ def run(args: list[str]) -> int:
 
         return arguments.func(arguments)
     except ChangelogError as e:
-        LOGGER.error(str(e))
+        LOGGER.error("{}", str(e))
         if verbosity > 2:
             traceback.print_exc()
         return C.RC_COMMAND_FAILED

--- a/src/antsibull_changelog/config.py
+++ b/src/antsibull_changelog/config.py
@@ -374,7 +374,7 @@ class ChangelogConfig(p.BaseModel):
     is_collection: bool
     config: dict
 
-    title: str | None = None
+    title: t.Optional[str] = None
     notes_dir: str = p.Field(default="fragments", alias="notesdir")
     prelude_name: str = p.Field(default="release_summary", alias="prelude_section_name")
     prelude_title: str = p.Field(
@@ -386,11 +386,11 @@ class ChangelogConfig(p.BaseModel):
     keep_fragments: bool = False
     prevent_known_fragments: bool  # default is set in parse()
     use_fqcn: bool = False
-    archive_path_template: str | None = None
+    archive_path_template: t.Optional[str] = None
     changelog_filename_template: str = "CHANGELOG-v%s.rst"
     changelog_filename_version_depth: int = 2
     mention_ancestor: bool = True
-    trivial_section_name: str | None  # default is set by parse()
+    trivial_section_name: t.Optional[str]  # default is set by parse()
     release_tag_re: str = r"((?:[\d.ab]|rc)+)"  # only relevant for ansible-core
     pre_release_tag_re: str = (
         r"(?P<pre_release>\.\d+(?:[ab]|rc)+\d*)$"  # only relevant for ansible-core
@@ -398,7 +398,7 @@ class ChangelogConfig(p.BaseModel):
     always_refresh: str = "none"
     ignore_other_fragment_extensions: bool = False
     sanitize_changelog: bool = False
-    flatmap: bool | None = None
+    flatmap: t.Optional[bool] = None
     use_semantic_versioning: bool = (
         True  # default is False for ansible-core and other projects
     )

--- a/src/antsibull_changelog/config.py
+++ b/src/antsibull_changelog/config.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 
 import enum
 import os
+import typing as t
 from collections.abc import Mapping
 from collections.abc import Sequence as _Sequence
-from typing import Any, Literal, Self
 
 import pydantic as p
 from antsibull_fileutils.yaml import load_yaml_file, store_yaml_file
@@ -24,7 +24,7 @@ from .errors import ChangelogError
 from .logger import LOGGER
 
 
-def _is_sequence(value: Any) -> bool:
+def _is_sequence(value: t.Any) -> bool:
     if not isinstance(value, _Sequence):
         return False
     return not isinstance(value, (str, bytes))
@@ -382,7 +382,7 @@ class ChangelogConfig(p.BaseModel):
     )
     new_plugins_after_name: str = ""  # not used
     changes_file: str = ".changes.yaml"
-    changes_format: Literal["combined"]
+    changes_format: t.Literal["combined"]
     keep_fragments: bool = False
     prevent_known_fragments: bool  # default is set in parse()
     use_fqcn: bool = False
@@ -407,17 +407,17 @@ class ChangelogConfig(p.BaseModel):
     output_formats: set[TextFormat] = {TextFormat.RESTRUCTURED_TEXT}
     add_plugin_period: bool = False
     changelog_nice_yaml: bool = False
-    changelog_sort: Literal[
+    changelog_sort: t.Literal[
         "unsorted",
         "version",
         "version_reversed",
         "alphanumerical",
     ] = "alphanumerical"
-    vcs: Literal["none", "auto", "git"] = "none"
+    vcs: t.Literal["none", "auto", "git"] = "none"
 
     @p.field_validator("always_refresh", mode="before")
     @classmethod
-    def fix_always_refresh(cls, value: Any) -> str:
+    def fix_always_refresh(cls, value: t.Any) -> str:
         """
         Validate and adjust the value of always_refresh.
         """
@@ -447,7 +447,7 @@ class ChangelogConfig(p.BaseModel):
 
     @p.field_validator("sections", mode="before")
     @classmethod
-    def parse_sections(cls, value: Any) -> Mapping[str, str]:
+    def parse_sections(cls, value: t.Any) -> Mapping[str, str]:
         """
         Parse the value of sections.
         """
@@ -481,7 +481,7 @@ class ChangelogConfig(p.BaseModel):
 
     @p.field_validator("output_formats", mode="before")
     @classmethod
-    def parse_output_formats(cls, value: Any) -> set[TextFormat]:
+    def parse_output_formats(cls, value: t.Any) -> set[TextFormat]:
         """
         Parse the value of output_formats.
         """
@@ -509,7 +509,7 @@ class ChangelogConfig(p.BaseModel):
         return result
 
     @p.model_validator(mode="after")
-    def postprocess_sections(self) -> Self:
+    def postprocess_sections(self) -> t.Self:
         """
         Postprocess sections value by inserting the prelude section.
         """
@@ -524,7 +524,7 @@ class ChangelogConfig(p.BaseModel):
         return self
 
     @p.model_validator(mode="after")
-    def validate_use_semantic_versioning(self) -> Self:
+    def validate_use_semantic_versioning(self) -> t.Self:
         """
         Validate use_semantic_versioning for collections.
         """

--- a/tests/units/test_config.py
+++ b/tests/units/test_config.py
@@ -352,7 +352,7 @@ def test_config_loading_bad_output_format(ansible_config_path):
     collection_details = CollectionDetails(paths)
     with pytest.raises(
         ChangelogError,
-        match="Found unknown extension in output_formats: Unknown extension 'foobar'",
+        match="The 1st entry of config value output_formats is an unknown extension: Unknown extension 'foobar'",
     ):
         ChangelogConfig.load(paths, collection_details)
 
@@ -363,6 +363,6 @@ def test_config_loading_bad_vcs(ansible_config_path):
     collection_details = CollectionDetails(paths)
     with pytest.raises(
         ChangelogError,
-        match="Invalid VCS value 'foobar'. Must be one of none, git, and auto.",
+        match="Input should be 'none', 'auto' or 'git'",
     ):
         ChangelogConfig.load(paths, collection_details)

--- a/tests/units/test_config.py
+++ b/tests/units/test_config.py
@@ -10,6 +10,7 @@ Test config module.
 from __future__ import annotations
 
 import os
+import re
 
 import pytest
 
@@ -20,52 +21,62 @@ from antsibull_changelog.errors import ChangelogError
 @pytest.fixture
 def root():
     old_cwd = os.getcwd()
-    os.chdir("/")
-    yield
-    os.chdir(old_cwd)
+    try:
+        os.chdir("/")
+        yield
+    finally:
+        os.chdir(old_cwd)
 
 
 @pytest.fixture
 def cwd_tmp_path(tmp_path):
     old_cwd = os.getcwd()
-    os.chdir(tmp_path)
-    yield tmp_path
-    os.chdir(old_cwd)
+    try:
+        os.chdir(tmp_path)
+        yield tmp_path
+    finally:
+        os.chdir(old_cwd)
 
 
 @pytest.fixture
 def ansible_config_path(tmp_path):
     old_cwd = os.getcwd()
-    os.chdir(tmp_path)
-    d = tmp_path / "lib"
-    d.mkdir()
-    d = d / "ansible"
-    d.mkdir()
-    d = tmp_path / "changelogs"
-    d.mkdir()
-    yield d / "config.yaml"
-    os.chdir(old_cwd)
+    try:
+        os.chdir(tmp_path)
+        d = tmp_path / "lib"
+        d.mkdir()
+        d = d / "ansible"
+        d.mkdir()
+        d = tmp_path / "changelogs"
+        d.mkdir()
+        yield d / "config.yaml"
+    finally:
+        os.chdir(old_cwd)
 
 
 @pytest.fixture
 def collection_config_path(tmp_path):
     old_cwd = os.getcwd()
-    os.chdir(tmp_path)
-    (tmp_path / "galaxy.yml").write_text("")
-    d = tmp_path / "changelogs"
-    d.mkdir()
-    yield d / "config.yaml"
-    os.chdir(old_cwd)
+    try:
+        os.chdir(tmp_path)
+        (tmp_path / "galaxy.yml").write_text("")
+        d = tmp_path / "changelogs"
+        d.mkdir()
+        yield d / "config.yaml"
+    finally:
+        os.chdir(old_cwd)
 
 
 @pytest.fixture
 def other_config_path(tmp_path):
     old_cwd = os.getcwd()
-    os.chdir(tmp_path)
-    d = tmp_path / "changelogs"
-    d.mkdir()
-    yield d / "config.yaml"
-    os.chdir(old_cwd)
+    try:
+        os.chdir(tmp_path)
+        d = tmp_path / "changelogs"
+        d.mkdir()
+        yield d / "config.yaml"
+    finally:
+        os.chdir(old_cwd)
 
 
 def test_detect_complete_fail(root):
@@ -288,6 +299,14 @@ def test_collection_details(tmp_path):
     assert "Cannot find galaxy.yml" in str(exc.value)
 
     galaxy_path = tmp_path / "galaxy.yml"
+    galaxy_path.write_text("---\nfoo")
+    paths = PathsConfig.force_collection(str(tmp_path))
+    details = CollectionDetails(paths)
+    with pytest.raises(ChangelogError) as exc:
+        details.get_namespace()
+    assert "galaxy.yml must be a dictionary" in str(exc.value)
+
+    galaxy_path = tmp_path / "galaxy.yml"
     galaxy_path.write_text("---\na: b\n")
     paths = PathsConfig.force_collection(str(tmp_path))
     details = CollectionDetails(paths)
@@ -346,10 +365,35 @@ def test_collection_details(tmp_path):
     assert details.get_flatmap() is False
 
 
-def test_config_loading_bad_output_format(ansible_config_path):
-    ansible_config_path.write_text("changes_format: combined\noutput_formats: [foobar]")
+def test_config_loading_bad_output_format(collection_config_path):
+    collection_config_path.write_text("changes_format: combined\noutput_formats: 42")
     paths = PathsConfig.detect()
     collection_details = CollectionDetails(paths)
+    with pytest.raises(
+        ChangelogError,
+        match="The config value output_formats must be a list",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    collection_config_path.write_text("changes_format: combined\noutput_formats:\n- 42")
+    with pytest.raises(
+        ChangelogError,
+        match="The 1st entry of config value output_formats is not a string",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    collection_config_path.write_text(
+        "changes_format: combined\noutput_formats: [rst, rst]"
+    )
+    with pytest.raises(
+        ChangelogError,
+        match="The output format 'rst' appears more than once",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    collection_config_path.write_text(
+        "changes_format: combined\noutput_formats: [foobar]"
+    )
     with pytest.raises(
         ChangelogError,
         match="The 1st entry of config value output_formats is an unknown extension: Unknown extension 'foobar'",
@@ -357,12 +401,159 @@ def test_config_loading_bad_output_format(ansible_config_path):
         ChangelogConfig.load(paths, collection_details)
 
 
-def test_config_loading_bad_vcs(ansible_config_path):
-    ansible_config_path.write_text("changes_format: combined\nvcs: foobar")
+def test_config_loading_bad_vcs(collection_config_path):
+    collection_config_path.write_text("changes_format: combined\nvcs: foobar")
     paths = PathsConfig.detect()
     collection_details = CollectionDetails(paths)
     with pytest.raises(
         ChangelogError,
         match="Input should be 'none', 'auto' or 'git'",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+
+def test_config_loading_always_refresh(ansible_config_path):
+    ansible_config_path.write_text(
+        "changes_format: combined\nalways_refresh: plugins, fragments"
+    )
+    paths = PathsConfig.detect()
+    collection_details = CollectionDetails(paths)
+    config = ChangelogConfig.load(paths, collection_details)
+    config.always_refresh == "plugins, fragments"
+
+    ansible_config_path.write_text("changes_format: combined\nalways_refresh: 42")
+    with pytest.raises(
+        ChangelogError,
+        match="If specified, always_refresh must be a boolean or a string",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    ansible_config_path.write_text(
+        "changes_format: combined\nalways_refresh: plugins, bar"
+    )
+    with pytest.raises(
+        ChangelogError,
+        match='The config value always_refresh contains an invalid value "bar"',
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    ansible_config_path.write_text(
+        "changes_format: combined\nalways_refresh: plugins, full"
+    )
+    with pytest.raises(
+        ChangelogError,
+        match='The config value always_refresh must not contain "full" together with other values',
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+
+def test_config_loading_bad_sections(collection_config_path):
+    collection_config_path.write_text("changes_format: combined\nsections: 42")
+    paths = PathsConfig.detect()
+    collection_details = CollectionDetails(paths)
+    with pytest.raises(
+        ChangelogError,
+        match="The config value sections must be a list",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    collection_config_path.write_text("changes_format: combined\nsections:\n  42: foo")
+    with pytest.raises(
+        ChangelogError,
+        match="The config value sections must be a dictionary mapping strings to strings",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    collection_config_path.write_text("changes_format: combined\nsections:\n  foo: 42")
+    with pytest.raises(
+        ChangelogError,
+        match="The config value sections must be a dictionary mapping strings to strings",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    collection_config_path.write_text(
+        "changes_format: combined\nsections:\n- [foo, bar]\n- foo"
+    )
+    with pytest.raises(
+        ChangelogError,
+        match="The 2nd entry of config value sections must be a list of length 2",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    collection_config_path.write_text(
+        "changes_format: combined\nsections:\n- [foo, bar]\n- [baz, bam]\n- [foo]"
+    )
+    with pytest.raises(
+        ChangelogError,
+        match="The 3rd entry of config value sections must be a list of length 2",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    collection_config_path.write_text(
+        "changes_format: combined\nsections:\n- [foo, bar]\n- [baz, bam]\n- [bam, foo]\n- [1, foo]"
+    )
+    with pytest.raises(
+        ChangelogError,
+        match="The 4th entry of config value sections does not have a string as the first element",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    collection_config_path.write_text(
+        "changes_format: combined\nsections:\n- [foo, bar]\n- [baz, bam]\n- [bam, foo]\n- [foo, 1]"
+    )
+    with pytest.raises(
+        ChangelogError,
+        match="The 4th entry of config value sections does not have a string as the second element",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    collection_config_path.write_text(
+        "changes_format: combined\nsections:\n- [foo, bar]\n- [foo, baz]"
+    )
+    with pytest.raises(
+        ChangelogError,
+        match="The section name 'foo' appears more than once",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    collection_config_path.write_text(
+        "changes_format: combined\nsections:\n- [release_summary, foo]"
+    )
+    with pytest.raises(
+        ChangelogError,
+        match=re.escape("No section name must equal prelude_name ('release_summary')"),
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+
+def test_config_loading_collection(collection_config_path):
+    collection_config_path.write_text(
+        "changes_format: combined\nuse_semantic_versioning: false"
+    )
+    paths = PathsConfig.detect()
+    collection_details = CollectionDetails(paths)
+    with pytest.raises(
+        ChangelogError,
+        match="The config value use_semantic_versioning must be true for collections",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+    collection_config_path.write_text(
+        "changes_format: combined\nis_other_project: true"
+    )
+    with pytest.raises(
+        ChangelogError,
+        match="is_other_project must not be true for collections",
+    ):
+        ChangelogConfig.load(paths, collection_details)
+
+
+def test_config_loading_bad_yaml(collection_config_path):
+    collection_config_path.write_text("[]")
+    paths = PathsConfig.detect()
+    collection_details = CollectionDetails(paths)
+    with pytest.raises(
+        ChangelogError,
+        match=" must be a dictionary",
     ):
         ChangelogConfig.load(paths, collection_details)


### PR DESCRIPTION
To prepare https://github.com/ansible-community/antsibull-changelog/issues/190#issuecomment-2628377419, I'd like to use pydantic to validate the config. This would also allow to add a config validator (~~which I'll likely do in this PR as well~~).