### PR TITLE
Fix integration tests; make --strict a proper flag

### DIFF
--- a/changelogs/fragments/196-lint-strict.yml
+++ b/changelogs/fragments/196-lint-strict.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - "The ``--strict`` option of the ``lint-changelog-yaml`` subcommand no longer expects a parameter. It now matches what was documented (https://github.com/ansible-community/antsibull-changelog/issues/195, https://github.com/ansible-community/antsibull-changelog/pull/196)."

--- a/docs/changelog.yaml-format.md
+++ b/docs/changelog.yaml-format.md
@@ -21,7 +21,7 @@ You can use the `antsibull-changelog lint-changelog-yaml` tool included in the [
 
 The tool does not output anything and exits with exit code 0 in case the file is OK, and outputs errors and exits with exit code 3 in case an error was found. Other exit codes indicate problems with the command line or during the execution of the linter.
 
-To avoid extra data in `changelog.yaml` that should not be in there, add the `--strict` option. This can be useful to avoid typos, for example if you wrote `change:` instead of `changes:`, or forgot `changes:` alltogether.
+To avoid extra data in `changelog.yaml` that should not be in there, add the `--strict true` option. This can be useful to avoid typos, for example if you wrote `change:` instead of `changes:`, or forgot `changes:` alltogether.
 
 
 ## changelog.yaml

--- a/docs/changelog.yaml-format.md
+++ b/docs/changelog.yaml-format.md
@@ -21,7 +21,7 @@ You can use the `antsibull-changelog lint-changelog-yaml` tool included in the [
 
 The tool does not output anything and exits with exit code 0 in case the file is OK, and outputs errors and exits with exit code 3 in case an error was found. Other exit codes indicate problems with the command line or during the execution of the linter.
 
-To avoid extra data in `changelog.yaml` that should not be in there, add the `--strict true` option. This can be useful to avoid typos, for example if you wrote `change:` instead of `changes:`, or forgot `changes:` alltogether.
+To avoid extra data in `changelog.yaml` that should not be in there, add the `--strict` option. This can be useful to avoid typos, for example if you wrote `change:` instead of `changes:`, or forgot `changes:` alltogether.
 
 
 ## changelog.yaml

--- a/noxfile.py
+++ b/noxfile.py
@@ -130,6 +130,7 @@ def integration(session: nox.Session):
         "lint-changelog-yaml",
         "--no-semantic-versioning",
         "--strict",
+        "true",
         "changelogs/changelog.yaml",
     )
 
@@ -153,6 +154,7 @@ def integration(session: nox.Session):
         "lint-changelog-yaml",
         str(cg_destination / "changelogs" / "changelog.yaml"),
         "--strict",
+        "true",
     )
 
     combined = map(str, tmp.glob(".coverage.*"))

--- a/noxfile.py
+++ b/noxfile.py
@@ -109,7 +109,7 @@ def integration(session: nox.Session):
         "--source",
         "antsibull_changelog",
         "-m",
-        "antsibull_changelog.cli",
+        "antsibull_changelog.__main__",
         env=env,
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -109,7 +109,7 @@ def integration(session: nox.Session):
         "--source",
         "antsibull_changelog",
         "-m",
-        "antsibull_changelog.__main__",
+        "antsibull_changelog",
         env=env,
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -130,7 +130,6 @@ def integration(session: nox.Session):
         "lint-changelog-yaml",
         "--no-semantic-versioning",
         "--strict",
-        "true",
         "changelogs/changelog.yaml",
     )
 
@@ -154,7 +153,6 @@ def integration(session: nox.Session):
         "lint-changelog-yaml",
         str(cg_destination / "changelogs" / "changelog.yaml"),
         "--strict",
-        "true",
     )
 
     combined = map(str, tmp.glob(".coverage.*"))

--- a/src/antsibull_changelog/cli.py
+++ b/src/antsibull_changelog/cli.py
@@ -196,7 +196,7 @@ def create_argparser(program_name: str) -> argparse.ArgumentParser:
     )
     lint_changelog_yaml_parser.add_argument(
         "--strict",
-        type=parse_boolean_arg,
+        action="store_true",
         help="do more strict checking, for example complain about extra"
         " entries that are not mentioned in the changelog.yaml specification",
     )


### PR DESCRIPTION
The integration tests never ran anything, since `antsibull.cli` did not have an `if __name__ == "__main__"`...

Also `antsibull-changelog lint-changelog-yaml`'s `--strict` parameter requires a `true`/`false` (or `yes`/`no`) value.

Ref: #195.